### PR TITLE
Fixed some bugs and made some improvements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,7 +44,9 @@ set(ALL_FILES
 # Target
 ################################################################################
 # Use BUILD_SHARED_LIBS to determine if the library is STATIC or SHARED
-add_library(${PROJECT_NAME}_Shared SHARED ${ALL_FILES})
+if(NOT (CMAKE_SYSTEM_NAME STREQUAL "Emscripten"))
+  add_library(${PROJECT_NAME}_Shared SHARED ${ALL_FILES})
+endif()
 add_library(${PROJECT_NAME}_Static STATIC ${ALL_FILES})
 # Set 2 properties on the static target
 set_target_properties(
@@ -57,9 +59,11 @@ set_target_properties(
 ################################################################################
 # Specify include directories to use when compiling SDL3_gfx
 # Include SDL3 include folder
-target_include_directories(${PROJECT_NAME}_Shared PUBLIC
+if(NOT (CMAKE_SYSTEM_NAME STREQUAL "Emscripten"))
+  target_include_directories(${PROJECT_NAME}_Shared PUBLIC
     "${CMAKE_CURRENT_SOURCE_DIR}/../SDL/include"
-)
+  )
+endif()
 
 target_include_directories(${PROJECT_NAME}_Static PUBLIC
     "${CMAKE_CURRENT_SOURCE_DIR}/../SDL/include"
@@ -67,26 +71,35 @@ target_include_directories(${PROJECT_NAME}_Static PUBLIC
 ################################################################################
 # Dependencies
 ################################################################################
-# Include SDL3 as our only dependency
-set(ADDITIONAL_LIBRARY_DEPENDENCIES
-    "SDL3"
-)
 
-find_library(SDL3_LIB SDL3)
+if(CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
+  find_library(SDL3_LIB libSDL3.a)
+else()
+  find_library(SDL3_LIB SDL3)
+endif()
 
 # Specify libraries directories that we will link with SDL3_gfx
-target_link_libraries(${PROJECT_NAME}_Shared PUBLIC "${ADDITIONAL_LIBRARY_DEPENDENCIES}")
-target_link_libraries(${PROJECT_NAME}_Static PUBLIC "${ADDITIONAL_LIBRARY_DEPENDENCIES}")
+if(NOT(CMAKE_SYSTEM_NAME STREQUAL "Emscripten"))
+  target_link_libraries(${PROJECT_NAME}_Shared PUBLIC ${SDL3_LIB})
+endif()
+target_link_libraries(${PROJECT_NAME}_Static PUBLIC ${SDL3_LIB})
 
 # copy to default locations
-install (TARGETS ${PROJECT_NAME}_Shared
+if(CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
+  install (TARGETS ${PROJECT_NAME}_Static
     LIBRARY DESTINATION lib
     RUNTIME DESTINATION bin)
+else()
+  install (TARGETS ${PROJECT_NAME}_Shared
+    LIBRARY DESTINATION lib
+    RUNTIME DESTINATION bin)
+endif()
 
 
 ################################################################################
 # Sub-projects
 ################################################################################
 # build the test also
-add_subdirectory(test)
-
+if(NOT(CMAKE_SYSTEM_NAME STREQUAL "Emscripten"))
+  add_subdirectory(test)
+endif()

--- a/SDL3_rotozoom.c
+++ b/SDL3_rotozoom.c
@@ -1534,7 +1534,7 @@ SDL_Surface *shrinkSurface(SDL_Surface *src, int factorx, int factory)
 	* Lock the surface 
 	*/
 	if (SDL_MUSTLOCK(rz_src)) {
-		if (SDL_LockSurface(rz_src) < 0) {
+		if (!SDL_LockSurface(rz_src)) {
 			haveError = 1;
 			goto exitShrinkSurface;
 		}

--- a/test/TestGfx.c
+++ b/test/TestGfx.c
@@ -245,7 +245,7 @@ void ExecuteTest(SDL_Renderer *renderer, PrimitivesTestCaseFp testCase, int test
         SDL_snprintf(titletext, TLEN, "Test %2i %20s: %10.1f /sec", testNum, testName, fps);
 		textlength = (Sint16)strlen(titletext);
 	    stringRGBA (renderer, WIDTH/2-4*textlength,30-4,titletext,255,255,255,255);
-		SDL_Log(titletext);
+		SDL_Log("%s", titletext);
     }
 }
 

--- a/test/testimagefilter.c
+++ b/test/testimagefilter.c
@@ -25,9 +25,6 @@ TestImageFilter.c: test program for MMX filter routines
 
 #ifdef WIN32
 #include <windows.h>
-#ifndef bcmp
-#define bcmp(s1, s2, n) memcmp ((s1), (s2), (n))
-#endif
 #endif
 #include "SDL3_imageFilter.h"
 
@@ -93,7 +90,7 @@ void print_result(int mmx, char *label, unsigned char *src1, unsigned char *src2
 void print_compare(unsigned char *dst1, unsigned char *dst2) 
 { 
 	total_count++;
-	if (bcmp(dst1,dst2,SRC_SIZE)==0) {
+	if (memcmp(dst1,dst2,SRC_SIZE)==0) {
 		SDL_Log("OK\n");
 		ok_count++;
 	} else {


### PR DESCRIPTION
Hello! I've recently started to upgrade my libraries to SDL3. While compiling I've noticed some errors, so I've fixed.
1. Made test/testimagefilter.c multiplatform replacing bcmp() with memcmp().
2. Fixed a logical error in SDL3_rotozoom.c:1537, wich alway resulted in false.
3. Fixed a security error in test/TestGfx.c:248. This is potentially dangerous since a hacking attack know as "heartbleed" happened by this reason: buffer overflow.
I'm working on trying to compile it for emscripten and make it work in the web browsers. Thanks for reading!