### PR TITLE
Added multiple fixes on mult and shiftleft shift right filters.

### DIFF
--- a/SDL3_imageFilter.c
+++ b/SDL3_imageFilter.c
@@ -247,7 +247,7 @@ int SDL_imageFilterMult(unsigned char *Src1, unsigned char *Src2, unsigned char 
 }
 
 /*!
-\brief Filter using MultNor: D = S1 * S2
+\brief Filter using MultUnbound: D = S1 * S2 - No saturation
 
 \param Src1 Pointer to the start of the first source byte array (S1).
 \param Src2 Pointer to the start of the second source byte array (S2).
@@ -256,7 +256,7 @@ int SDL_imageFilterMult(unsigned char *Src1, unsigned char *Src2, unsigned char 
 
 \return Returns 0 for success or -1 for error.
 */
-int SDL_imageFilterMultNor(unsigned char *Src1, unsigned char *Src2, unsigned char *Dest, unsigned int length)
+int SDL_imageFilterMultUnbound(unsigned char *Src1, unsigned char *Src2, unsigned char *Dest, unsigned int length)
 {
 	unsigned int i, istart, tmp;
 	unsigned char *cursrc1, *cursrc2, *curdst;

--- a/SDL3_imageFilter.h
+++ b/SDL3_imageFilter.h
@@ -74,8 +74,8 @@ extern "C" {
 	//  SDL_imageFilterMult: D = saturation(S1 * S2)
 	SDL3_IMAGEFILTER_SCOPE int SDL_imageFilterMult(unsigned char *Src1, unsigned char *Src2, unsigned char *Dest, unsigned int length);
 
-	//  SDL_imageFilterMultNor: D = S1 * S2 unbound
-	SDL3_IMAGEFILTER_SCOPE int SDL_imageFilterMultNor(unsigned char *Src1, unsigned char *Src2, unsigned char *Dest, unsigned int length);
+	//  SDL_imageFilterMultUnbound: D = S1 * S2 unbound
+	SDL3_IMAGEFILTER_SCOPE int SDL_imageFilterMultUnbound(unsigned char *Src1, unsigned char *Src2, unsigned char *Dest, unsigned int length);
 
 	//  SDL_imageFilterMultInv: D = 255 - ((255 - S1) * (255 - S2))
 	SDL3_IMAGEFILTER_SCOPE int SDL_imageFilterMultInv(unsigned char *Src1, unsigned char *Src2, unsigned char *Dest, unsigned int length);

--- a/test/testimagefilter.c
+++ b/test/testimagefilter.c
@@ -150,7 +150,7 @@ int main(int argc, char *argv[])
 			FUNC(Mean),
 			FUNC(Sub),
 			FUNC(Mult),
-			FUNC(MultNor),
+			FUNC(MultUnbound),
 			FUNC(MultInv),
 			FUNC(MultDivby2),
 			FUNC(MultDivby4),


### PR DESCRIPTION
## About this PR 

So this PR aims to solve multiple issues with the Multiply / divide image filters. The filters changed were:

* `SDL_imageFilterMult`
* `SDL_imageFilterMultDivby2`
* `SDL_imageFilterMultDivby4`
* `SDL_imageFilterDiv`
* `SDL_imageFilterMultByByte`
* `SDL_imageFilterShiftRightAndMultByByte`
* `SDL_imageFilterNormalizeLinear`
* `SDL_imageFilterMean`

## Reason for this PR 
* Using them on an image would always show a black square.
    * My guess is that on old 16 bit machine these multiplier would cause `uint` overflow and roll back to the start, making interesting result with the multiplier. Or on old code the MMX filter would be used and never properly tested the C versions (the tests were failing before removing `MMX` code, so not really sure). Not really the the real cause of them not working though, just a guess.

## Change
* Changing all of these to use float operators, and converting them back to unsigned chars will fix these issues and also match filters similar to what you wold use on a paint program, like Krita. 

## Additional changes 

This also fixes some issues with the `ShiftRightUint` and `ShiftLeftUint` filters. These have similar problems to what the previous uint shift filter had (not taking int account the bytes per pixel value of the format)

And finally, added a new filter `SDL_imageFilterMultInv`, which I believe addresses what the original `SDL_imageFilterMultNor` attempts to achieve (I assume that `SDL_imageFilterMultNor` wants to make a unbounded multiplication, but I think new machines changed the equation and does osomething different as intended).

`SDL_imageFilterMultInv` Is in essence the opposite of `SDL_imageFilterMult`, also called a "screen effect".

## Results

So Like I've said before, I'm making SDL3 bindings on Vala, Here's a video of a sample project in Vala. I think I'd like to have this same test within `SDL_Gfx` to actually show how these filters are used in practice.

https://github.com/user-attachments/assets/9a746cf5-c020-46df-8c20-07fad2c2d45c

And besides, I looked high and low one the web, gituhb and beyond, and there seems that there are NO examples of these filters ever being used! (save for some obscure relaxation function example that uses 'one' filter). This would be like some of the first public examples of its kind apart from the basic tests that occur on arbitrary arrays.

I don't think this will make people use these filters more, but its still a nice piece of the library that could get resurrected by doing this.

## Future steps

I think these makes the filters, at least how they are, usable and existing on modern computers. There might not be that usable on modern GPUs, since tall of this is CPU based. But maybe someone who want to do some quick an dirti work can get some advantage of these, especially knowing how to use them.

Next steps are:
* Adapt the API to SDL3 idioms, in particular, address the return bool types (#8) and other niceties that could be done with native SDL libraries if warranted.
* Adapt the sample I made in Vala to C (not sure if this is warranted for the library though)
* Same as before try to make convolution filters work.

