### PR TITLE
Updating Gfx API to use floats and use bigger SDL types in signatures

### DIFF
--- a/SDL3_gfxPrimitives.c
+++ b/SDL3_gfxPrimitives.c
@@ -3706,7 +3706,7 @@ bool bezierRGBA(SDL_Renderer * renderer, const float * vx, const float * vy, Sin
 
 \returns Returns true on success, false on failure.
 */
-bool thickLineColor(SDL_Renderer *renderer, float x1, float y1, float x2, float y2, Uint8 width, Uint32 color)
+bool thickLineColor(SDL_Renderer *renderer, float x1, float y1, float x2, float y2, float width, Uint32 color)
 {
 	Uint8 *c = (Uint8 *)&color; 
 	return thickLineRGBA(renderer, x1, y1, x2, y2, width, c[0], c[1], c[2], c[3]);
@@ -3728,7 +3728,7 @@ bool thickLineColor(SDL_Renderer *renderer, float x1, float y1, float x2, float 
 
 \returns Returns true on success, false on failure.
 */
-bool thickLineRGBA(SDL_Renderer *renderer, float x1, float y1, float x2, float y2, Uint8 width, Uint8 r, Uint8 g, Uint8 b, Uint8 a)
+bool thickLineRGBA(SDL_Renderer *renderer, float x1, float y1, float x2, float y2, float width, Uint8 r, Uint8 g, Uint8 b, Uint8 a)
 {
 	Sint32 wh;
 	double dx, dy, dx1, dy1, dx2, dy2;

--- a/SDL3_gfxPrimitives.c
+++ b/SDL3_gfxPrimitives.c
@@ -438,11 +438,11 @@ bool roundedRectangleRGBA(SDL_Renderer * renderer, float x1, float y1, float x2,
 	*/
 	if ((rad * 2) > w)  
 	{
-		rad = w / 2;
+		rad = (Sint32) w / 2;
 	}
 	if ((rad * 2) > h)
 	{
-		rad = h / 2;
+		rad = (Sint32) h / 2;
 	}
 
 	/*
@@ -592,12 +592,12 @@ bool roundedBoxRGBA(SDL_Renderer * renderer, float x1, float y1, float x2,
 	r2 = rad + rad;
 	if (r2 > w)  
 	{
-		rad = w / 2;
+		rad = (Sint32) w / 2;
 		r2 = rad + rad;
 	}
 	if (r2 > h)
 	{
-		rad = h / 2;
+		rad = (Sint32) h / 2;
 	}
 
 	/* Setup filled circle drawing for corners */
@@ -1068,7 +1068,7 @@ bool _aalineRGBA(SDL_Renderer * renderer, float x1, float y1, float x2, float y2
 bool aalineColor(SDL_Renderer * renderer, float x1, float y1, float x2, float y2, Uint32 color)
 {
 	Uint8 *c = (Uint8 *)&color; 
-	return _aalineRGBA(renderer, x1, y1, x2, y2, c[0], c[1], c[2], c[3], 1);
+	return _aalineRGBA(renderer, x1, y1, x2, y2, c[0], c[1], c[2], c[3], true);
 }
 
 /*!
@@ -1506,10 +1506,10 @@ bool _drawQuadrants(SDL_Renderer * renderer,  float x, float y, float dx, float 
 bool _ellipseRGBA(SDL_Renderer * renderer, float x, float y, float rx, float ry, Uint8 r, Uint8 g, Uint8 b, Uint8 a, bool f)
 {
 	bool result;
-	float rxi, ryi;
-	float rx2, ry2, rx22, ry22;
+	Sint32 rxi, ryi;
+	Sint32 rx2, ry2, rx22, ry22;
     Sint32 error;
-    float curX, curY, curXp1, curYm1;
+    Sint32 curX, curY, curXp1, curYm1;
 	Sint32 scrX, scrY, oldX, oldY;
     Sint32 deltaX, deltaY;
 	Sint32 ellipseOverscan;
@@ -1668,7 +1668,7 @@ bool _ellipseRGBA(SDL_Renderer * renderer, float x, float y, float rx, float ry,
 bool ellipseColor(SDL_Renderer * renderer, float x, float y, float rx, float ry, Uint32 color)
 {
 	Uint8 *c = (Uint8 *)&color; 
-	return _ellipseRGBA(renderer, x, y, rx, ry, c[0], c[1], c[2], c[3], 0);
+	return _ellipseRGBA(renderer, x, y, rx, ry, c[0], c[1], c[2], c[3], false);
 }
 
 /*!
@@ -1688,7 +1688,7 @@ bool ellipseColor(SDL_Renderer * renderer, float x, float y, float rx, float ry,
 */
 bool ellipseRGBA(SDL_Renderer * renderer, float x, float y, float rx, float ry, Uint8 r, Uint8 g, Uint8 b, Uint8 a)
 {
-	return _ellipseRGBA(renderer, x, y, rx, ry, r, g, b, a, 0);
+	return _ellipseRGBA(renderer, x, y, rx, ry, r, g, b, a, false);
 }
 
 /* ----- Filled Circle */
@@ -1726,7 +1726,7 @@ bool filledCircleColor(SDL_Renderer * renderer, float x, float y, float rad, Uin
 */
 bool filledCircleRGBA(SDL_Renderer * renderer, float x, float y, float rad, Uint8 r, Uint8 g, Uint8 b, Uint8 a)
 {
-	return _ellipseRGBA(renderer, x, y, rad, rad, r, g ,b, a, 1);
+	return _ellipseRGBA(renderer, x, y, rad, rad, r, g ,b, a, true);
 }
 
 
@@ -2003,7 +2003,7 @@ bool aaellipseRGBA(SDL_Renderer * renderer, float x, float y, float rx, float ry
 bool filledEllipseColor(SDL_Renderer * renderer, float x, float y, float rx, float ry, Uint32 color)
 {
 	Uint8 *c = (Uint8 *)&color; 
-	return _ellipseRGBA(renderer, x, y, rx, ry, c[0], c[1], c[2], c[3], 1);
+	return _ellipseRGBA(renderer, x, y, rx, ry, c[0], c[1], c[2], c[3], true);
 }
 
 /*!
@@ -2023,7 +2023,7 @@ bool filledEllipseColor(SDL_Renderer * renderer, float x, float y, float rx, flo
 */
 bool filledEllipseRGBA(SDL_Renderer * renderer, float x, float y, float rx, float ry, Uint8 r, Uint8 g, Uint8 b, Uint8 a)
 {
-	return _ellipseRGBA(renderer, x, y, rx, ry, r, g, b, a, 1);
+	return _ellipseRGBA(renderer, x, y, rx, ry, r, g, b, a, true);
 }
 
 /* ----- Pie */
@@ -2167,7 +2167,7 @@ bool pieColor(SDL_Renderer * renderer, float x, float y, float rad,
 	Sint32 start, Sint32 end, Uint32 color)
 {
 	Uint8 *c = (Uint8 *)&color; 
-	return _pieRGBA(renderer, x, y, rad, start, end, c[0], c[1], c[2], c[3], 0);
+	return _pieRGBA(renderer, x, y, rad, start, end, c[0], c[1], c[2], c[3], false);
 }
 
 /*!
@@ -2189,7 +2189,7 @@ bool pieColor(SDL_Renderer * renderer, float x, float y, float rad,
 bool pieRGBA(SDL_Renderer * renderer, float x, float y, float rad,
 	Sint32 start, Sint32 end, Uint8 r, Uint8 g, Uint8 b, Uint8 a)
 {
-	return _pieRGBA(renderer, x, y, rad, start, end, r, g, b, a, 0);
+	return _pieRGBA(renderer, x, y, rad, start, end, r, g, b, a, false);
 }
 
 /*!
@@ -2208,7 +2208,7 @@ bool pieRGBA(SDL_Renderer * renderer, float x, float y, float rad,
 bool filledPieColor(SDL_Renderer * renderer, float x, float y, float rad, Sint32 start, Sint32 end, Uint32 color)
 {
 	Uint8 *c = (Uint8 *)&color; 
-	return _pieRGBA(renderer, x, y, rad, start, end, c[0], c[1], c[2], c[3], 1);
+	return _pieRGBA(renderer, x, y, rad, start, end, c[0], c[1], c[2], c[3], true);
 }
 
 /*!
@@ -2230,7 +2230,7 @@ bool filledPieColor(SDL_Renderer * renderer, float x, float y, float rad, Sint32
 bool filledPieRGBA(SDL_Renderer * renderer, float x, float y, float rad,
 	Sint32 start, Sint32 end, Uint8 r, Uint8 g, Uint8 b, Uint8 a)
 {
-	return _pieRGBA(renderer, x, y, rad, start, end, r, g, b, a, 1);
+	return _pieRGBA(renderer, x, y, rad, start, end, r, g, b, a, true);
 }
 
 /* ------ Trigon */
@@ -2645,14 +2645,14 @@ bool aapolygonRGBA(SDL_Renderer * renderer, const float * vx, const float * vy, 
 	*/
 	result = true;
 	for (i = 1; i < n; i++) {
-		result &= _aalineRGBA(renderer, *x1, *y1, *x2, *y2, r, g, b, a, 0);
+		result &= _aalineRGBA(renderer, *x1, *y1, *x2, *y2, r, g, b, a, false);
 		x1 = x2;
 		y1 = y2;
 		x2++;
 		y2++;
 	}
 
-	result &= _aalineRGBA(renderer, *x1, *y1, *vx, *vy, r, g, b, a, 0);
+	result &= _aalineRGBA(renderer, *x1, *y1, *vx, *vy, r, g, b, a, false);
 
 	return (result);
 }
@@ -2966,7 +2966,7 @@ bool _HLineTextured(SDL_Renderer *renderer, float x1, float x2, float y, SDL_Tex
 		source_rect.x = texture_x_walker;
 		dst_rect.x= x1;
 		dst_rect.w = source_rect.w;
-		result = (SDL_RenderTexture(renderer, texture, &source_rect, &dst_rect) == 0);
+		result = SDL_RenderTexture(renderer, texture, &source_rect, &dst_rect);
 	} else { 
 		/* we need to draw multiple times */
 		/* draw the first segment */
@@ -2975,7 +2975,7 @@ bool _HLineTextured(SDL_Renderer *renderer, float x1, float x2, float y, SDL_Tex
 		source_rect.x = texture_x_walker;
 		dst_rect.x= x1;
 		dst_rect.w = source_rect.w;
-		result &= (SDL_RenderTexture(renderer, texture, &source_rect, &dst_rect) == 0);
+		result &= SDL_RenderTexture(renderer, texture, &source_rect, &dst_rect);
 		write_width = texture_w;
 
 		/* now draw the rest */
@@ -2988,7 +2988,7 @@ bool _HLineTextured(SDL_Renderer *renderer, float x1, float x2, float y, SDL_Tex
 			source_rect.w = write_width;
 			dst_rect.x = x1 + pixels_written;
 			dst_rect.w = source_rect.w;
-			result &= (SDL_RenderTexture(renderer, texture, &source_rect, &dst_rect) == 0);
+			result &= SDL_RenderTexture(renderer, texture, &source_rect, &dst_rect);
 			pixels_written += write_width;
 		}
 	}
@@ -3674,12 +3674,12 @@ bool bezierRGBA(SDL_Renderer * renderer, const float * vx, const float * vy, Sin
 	* Draw 
 	*/
 	t=0.0;
-	x1=(float)lrint(_evaluateBezier(x,n+1,t));
-	y1=(float)lrint(_evaluateBezier(y,n+1,t));
+	x1=(Sint32)lrint(_evaluateBezier(x,n+1,t));
+	y1=(Sint32)lrint(_evaluateBezier(y,n+1,t));
 	for (i = 0; i <= (n*s); i++) {
 		t += stepsize;
-		x2=(float)_evaluateBezier(x,n,t);
-		y2=(float)_evaluateBezier(y,n,t);
+		x2=(Sint32)_evaluateBezier(x,n,t);
+		y2=(Sint32)_evaluateBezier(y,n,t);
 		result &= line(renderer, x1, y1, x2, y2);
 		x1 = x2;
 		y1 = y2;

--- a/SDL3_gfxPrimitives.c
+++ b/SDL3_gfxPrimitives.c
@@ -47,7 +47,7 @@ Andreas Schiffler -- aschiffler at ferzkopp dot net
 
 \returns Returns true on success, false on failure.
 */
-bool pixel(SDL_Renderer *renderer, Sint16 x, Sint16 y)
+bool pixel(SDL_Renderer *renderer, float x, float y)
 {
 	return SDL_RenderPoint(renderer, x, y);
 }
@@ -62,7 +62,7 @@ bool pixel(SDL_Renderer *renderer, Sint16 x, Sint16 y)
 
 \returns Returns true on success, false on failure.
 */
-bool pixelColor(SDL_Renderer * renderer, Sint16 x, Sint16 y, Uint32 color)
+bool pixelColor(SDL_Renderer * renderer, float x, float y, Uint32 color)
 {
 	Uint8 *c = (Uint8 *)&color; 
 	return pixelRGBA(renderer, x, y, c[0], c[1], c[2], c[3]);
@@ -81,7 +81,7 @@ bool pixelColor(SDL_Renderer * renderer, Sint16 x, Sint16 y, Uint32 color)
 
 \returns Returns true on success, false on failure.
 */
-bool pixelRGBA(SDL_Renderer * renderer, Sint16 x, Sint16 y, Uint8 r, Uint8 g, Uint8 b, Uint8 a)
+bool pixelRGBA(SDL_Renderer * renderer, float x, float y, Uint8 r, Uint8 g, Uint8 b, Uint8 a)
 {
 	bool result = true;
 	result &= SDL_SetRenderDrawBlendMode(renderer, (a == 255) ? SDL_BLENDMODE_NONE : SDL_BLENDMODE_BLEND);
@@ -104,12 +104,12 @@ bool pixelRGBA(SDL_Renderer * renderer, Sint16 x, Sint16 y, Uint8 r, Uint8 g, Ui
 
 \returns Returns true on success, false on failure.
 */
-bool pixelRGBAWeight(SDL_Renderer * renderer, Sint16 x, Sint16 y, Uint8 r, Uint8 g, Uint8 b, Uint8 a, Uint32 weight)
+bool pixelRGBAWeight(SDL_Renderer * renderer, float x, float y, Uint8 r, Uint8 g, Uint8 b, Uint8 a, unsigned int weight)
 {
 	/*
 	* Modify Alpha by weight 
 	*/
-	Uint32 ax = a;
+	unsigned int ax = a;
 	ax = ((ax * weight) >> 8);
 	if (ax > 255) {
 		a = 255;
@@ -132,7 +132,7 @@ bool pixelRGBAWeight(SDL_Renderer * renderer, Sint16 x, Sint16 y, Uint8 r, Uint8
 
 \returns Returns true on success, false on failure.
 */
-bool hline(SDL_Renderer * renderer, Sint16 x1, Sint16 x2, Sint16 y)
+bool hline(SDL_Renderer * renderer, float x1, float x2, float y)
 {
 	return SDL_RenderLine(renderer, x1, y, x2, y);;
 }
@@ -149,7 +149,7 @@ bool hline(SDL_Renderer * renderer, Sint16 x1, Sint16 x2, Sint16 y)
 
 \returns Returns true on success, false on failure.
 */
-bool hlineColor(SDL_Renderer * renderer, Sint16 x1, Sint16 x2, Sint16 y, Uint32 color)
+bool hlineColor(SDL_Renderer * renderer, float x1, float x2, float y, Uint32 color)
 {
 	Uint8 *c = (Uint8 *)&color; 
 	return hlineRGBA(renderer, x1, x2, y, c[0], c[1], c[2], c[3]);
@@ -169,7 +169,7 @@ bool hlineColor(SDL_Renderer * renderer, Sint16 x1, Sint16 x2, Sint16 y, Uint32 
 
 \returns Returns true on success, false on failure.
 */
-bool hlineRGBA(SDL_Renderer * renderer, Sint16 x1, Sint16 x2, Sint16 y, Uint8 r, Uint8 g, Uint8 b, Uint8 a)
+bool hlineRGBA(SDL_Renderer * renderer, float x1, float x2, float y, Uint8 r, Uint8 g, Uint8 b, Uint8 a)
 {
 	bool result = true;
 	result &= SDL_SetRenderDrawBlendMode(renderer, (a == 255) ? SDL_BLENDMODE_NONE : SDL_BLENDMODE_BLEND);
@@ -190,7 +190,7 @@ bool hlineRGBA(SDL_Renderer * renderer, Sint16 x1, Sint16 x2, Sint16 y, Uint8 r,
 
 \returns Returns true on success, false on failure.
 */
-bool vline(SDL_Renderer * renderer, Sint16 x, Sint16 y1, Sint16 y2)
+bool vline(SDL_Renderer * renderer, float x, float y1, float y2)
 {
 	return SDL_RenderLine(renderer, x, y1, x, y2);;
 }
@@ -206,7 +206,7 @@ bool vline(SDL_Renderer * renderer, Sint16 x, Sint16 y1, Sint16 y2)
 
 \returns Returns true on success, false on failure.
 */
-bool vlineColor(SDL_Renderer * renderer, Sint16 x, Sint16 y1, Sint16 y2, Uint32 color)
+bool vlineColor(SDL_Renderer * renderer, float x, float y1, float y2, Uint32 color)
 {
 	Uint8 *c = (Uint8 *)&color; 
 	return vlineRGBA(renderer, x, y1, y2, c[0], c[1], c[2], c[3]);
@@ -226,7 +226,7 @@ bool vlineColor(SDL_Renderer * renderer, Sint16 x, Sint16 y1, Sint16 y2, Uint32 
 
 \returns Returns true on success, false on failure.
 */
-bool vlineRGBA(SDL_Renderer * renderer, Sint16 x, Sint16 y1, Sint16 y2, Uint8 r, Uint8 g, Uint8 b, Uint8 a)
+bool vlineRGBA(SDL_Renderer * renderer, float x, float y1, float y2, Uint8 r, Uint8 g, Uint8 b, Uint8 a)
 {
 	bool result = true;
 	result &= SDL_SetRenderDrawBlendMode(renderer, (a == 255) ? SDL_BLENDMODE_NONE : SDL_BLENDMODE_BLEND);
@@ -249,7 +249,7 @@ bool vlineRGBA(SDL_Renderer * renderer, Sint16 x, Sint16 y1, Sint16 y2, Uint8 r,
 
 \returns Returns true on success, false on failure.
 */
-bool rectangleColor(SDL_Renderer * renderer, Sint16 x1, Sint16 y1, Sint16 x2, Sint16 y2, Uint32 color)
+bool rectangleColor(SDL_Renderer * renderer, float x1, float y1, float x2, float y2, Uint32 color)
 {
 	Uint8 *c = (Uint8 *)&color; 
 	return rectangleRGBA(renderer, x1, y1, x2, y2, c[0], c[1], c[2], c[3]);
@@ -270,10 +270,10 @@ bool rectangleColor(SDL_Renderer * renderer, Sint16 x1, Sint16 y1, Sint16 x2, Si
 
 \returns Returns true on success, false on failure.
 */
-bool rectangleRGBA(SDL_Renderer * renderer, Sint16 x1, Sint16 y1, Sint16 x2, Sint16 y2, Uint8 r, Uint8 g, Uint8 b, Uint8 a)
+bool rectangleRGBA(SDL_Renderer * renderer, float x1, float y1, float x2, float y2, Uint8 r, Uint8 g, Uint8 b, Uint8 a)
 {
 	bool result;
-	Sint16 tmp;
+	float tmp;
 	SDL_FRect rect;
 
 	/*
@@ -342,7 +342,7 @@ bool rectangleRGBA(SDL_Renderer * renderer, Sint16 x1, Sint16 y1, Sint16 x2, Sin
 
 \returns Returns true on success, false on failure.
 */
-bool roundedRectangleColor(SDL_Renderer * renderer, Sint16 x1, Sint16 y1, Sint16 x2, Sint16 y2, Sint16 rad, Uint32 color)
+bool roundedRectangleColor(SDL_Renderer * renderer, float x1, float y1, float x2, float y2, float rad, Uint32 color)
 {
 	Uint8 *c = (Uint8 *)&color; 
 	return roundedRectangleRGBA(renderer, x1, y1, x2, y2, rad, c[0], c[1], c[2], c[3]);
@@ -364,14 +364,14 @@ bool roundedRectangleColor(SDL_Renderer * renderer, Sint16 x1, Sint16 y1, Sint16
 
 \returns Returns true on success, false on failure.
 */
-bool roundedRectangleRGBA(SDL_Renderer * renderer, Sint16 x1, Sint16 y1, Sint16 x2, Sint16 y2, Sint16 rad, Uint8 r, Uint8 g, Uint8 b, Uint8 a)
+bool roundedRectangleRGBA(SDL_Renderer * renderer, float x1, float y1, float x2, float y2, float rad, Uint8 r, Uint8 g, Uint8 b, Uint8 a)
 {
 	int result = 0;
-	Sint16 tmp;
-	Sint16 w, h;
-	Sint16 xx1, xx2;
-	Sint16 yy1, yy2;
-	
+	float tmp;
+	float w, h;
+	float xx1, xx2;
+	float yy1, yy2;
+
 	/*
 	* Check renderer
 	*/
@@ -487,7 +487,7 @@ bool roundedRectangleRGBA(SDL_Renderer * renderer, Sint16 x1, Sint16 y1, Sint16 
 
 \returns Returns true on success, false on failure.
 */
-bool roundedBoxColor(SDL_Renderer * renderer, Sint16 x1, Sint16 y1, Sint16 x2, Sint16 y2, Sint16 rad, Uint32 color)
+bool roundedBoxColor(SDL_Renderer * renderer, float x1, float y1, float x2, float y2, float rad, Uint32 color)
 {
 	Uint8 *c = (Uint8 *)&color; 
 	return roundedBoxRGBA(renderer, x1, y1, x2, y2, rad, c[0], c[1], c[2], c[3]);
@@ -509,21 +509,21 @@ bool roundedBoxColor(SDL_Renderer * renderer, Sint16 x1, Sint16 y1, Sint16 x2, S
 
 \returns Returns true on success, false on failure.
 */
-bool roundedBoxRGBA(SDL_Renderer * renderer, Sint16 x1, Sint16 y1, Sint16 x2,
-	Sint16 y2, Sint16 rad, Uint8 r, Uint8 g, Uint8 b, Uint8 a)
+bool roundedBoxRGBA(SDL_Renderer * renderer, float x1, float y1, float x2,
+	float y2, float rad, Uint8 r, Uint8 g, Uint8 b, Uint8 a)
 {
 	bool result;
-	Sint16 w, h, r2, tmp;
-	Sint16 cx = 0;
-	Sint16 cy = rad;
-	Sint16 ocx = (Sint16) 0xffff;
-	Sint16 ocy = (Sint16) 0xffff;
-	Sint16 df = 1 - rad;
-	Sint16 d_e = 3;
-	Sint16 d_se = -2 * rad + 5;
-	Sint16 xpcx, xmcx, xpcy, xmcy;
-	Sint16 ypcy, ymcy, ypcx, ymcx;
-	Sint16 x, y, dx, dy;
+	float w, h, r2, tmp;
+	float cx = 0;
+	float cy = rad;
+	float ocx = (float) 0xffff;
+	float ocy = (float) 0xffff;
+	float df = 1 - rad;
+	float d_e = 3;
+	float d_se = -2 * rad + 5;
+	float xpcx, xmcx, xpcy, xmcy;
+	float ypcy, ymcy, ypcx, ymcx;
+	float x, y, dx, dy;
 
 	/* 
 	* Check destination renderer 
@@ -684,7 +684,7 @@ bool roundedBoxRGBA(SDL_Renderer * renderer, Sint16 x1, Sint16 y1, Sint16 x2,
 
 \returns Returns true on success, false on failure.
 */
-bool boxColor(SDL_Renderer * renderer, Sint16 x1, Sint16 y1, Sint16 x2, Sint16 y2, Uint32 color)
+bool boxColor(SDL_Renderer * renderer, float x1, float y1, float x2, float y2, Uint32 color)
 {
 	Uint8 *c = (Uint8 *)&color; 
 	return boxRGBA(renderer, x1, y1, x2, y2, c[0], c[1], c[2], c[3]);
@@ -705,10 +705,10 @@ bool boxColor(SDL_Renderer * renderer, Sint16 x1, Sint16 y1, Sint16 x2, Sint16 y
 
 \returns Returns true on success, false on failure.
 */
-bool boxRGBA(SDL_Renderer * renderer, Sint16 x1, Sint16 y1, Sint16 x2, Sint16 y2, Uint8 r, Uint8 g, Uint8 b, Uint8 a)
+bool boxRGBA(SDL_Renderer * renderer, float x1, float y1, float x2, float y2, Uint8 r, Uint8 g, Uint8 b, Uint8 a)
 {
 	bool result;
-	Sint16 tmp;
+	float tmp;
 	SDL_FRect rect;
 
 	/*
@@ -775,7 +775,7 @@ bool boxRGBA(SDL_Renderer * renderer, Sint16 x1, Sint16 y1, Sint16 x2, Sint16 y2
 
 \returns Returns true on success, false on failure.
 */
-bool line(SDL_Renderer * renderer, Sint16 x1, Sint16 y1, Sint16 x2, Sint16 y2)
+bool line(SDL_Renderer * renderer, float x1, float y1, float x2, float y2)
 {
 	/*
 	* Draw
@@ -795,7 +795,7 @@ bool line(SDL_Renderer * renderer, Sint16 x1, Sint16 y1, Sint16 x2, Sint16 y2)
 
 \returns Returns true on success, false on failure.
 */
-bool lineColor(SDL_Renderer * renderer, Sint16 x1, Sint16 y1, Sint16 x2, Sint16 y2, Uint32 color)
+bool lineColor(SDL_Renderer * renderer, float x1, float y1, float x2, float y2, Uint32 color)
 {
 	Uint8 *c = (Uint8 *)&color; 
 	return lineRGBA(renderer, x1, y1, x2, y2, c[0], c[1], c[2], c[3]);
@@ -816,7 +816,7 @@ bool lineColor(SDL_Renderer * renderer, Sint16 x1, Sint16 y1, Sint16 x2, Sint16 
 
 \returns Returns true on success, false on failure.
 */
-bool lineRGBA(SDL_Renderer * renderer, Sint16 x1, Sint16 y1, Sint16 x2, Sint16 y2, Uint8 r, Uint8 g, Uint8 b, Uint8 a)
+bool lineRGBA(SDL_Renderer * renderer, float x1, float y1, float x2, float y2, Uint8 r, Uint8 g, Uint8 b, Uint8 a)
 {
 	/*
 	* Draw
@@ -856,12 +856,12 @@ with alpha<255.
 
 \returns Returns true on success, false on failure.
 */
-int _aalineRGBA(SDL_Renderer * renderer, Sint16 x1, Sint16 y1, Sint16 x2, Sint16 y2, Uint8 r, Uint8 g, Uint8 b, Uint8 a, int draw_endpoint)
+bool _aalineRGBA(SDL_Renderer * renderer, float x1, float y1, float x2, float y2, Uint8 r, Uint8 g, Uint8 b, Uint8 a, bool draw_endpoint)
 {
-	Sint32 xx0, yy0, xx1, yy1;
+	float xx0, yy0, xx1, yy1;
 	bool result;
-	Uint32 intshift, erracc, erradj;
-	Uint32 erracctmp, wgt, wgtcompmask;
+	unsigned int intshift, erracc, erradj;
+	unsigned int erracctmp, wgt;
 	int dx, dy, tmp, xdir, y0p1, x0pxdir;
 
 	/*
@@ -955,12 +955,7 @@ int _aalineRGBA(SDL_Renderer * renderer, Sint16 x1, Sint16 y1, Sint16 x2, Sint16
 	intshift = 32 - AAbits;
 
 	/*
-	* Mask used to flip all bits in an intensity weighting 
-	*/
-	wgtcompmask = AAlevels - 1;
-
-	/*
-	* Draw the initial pixel in the foreground color 
+	* Draw the initial pixel in the foreground color
 	*/
 	result &= pixelRGBA(renderer, x1, y1, r, g, b, a);
 
@@ -1070,7 +1065,7 @@ int _aalineRGBA(SDL_Renderer * renderer, Sint16 x1, Sint16 y1, Sint16 x2, Sint16
 
 \returns Returns true on success, false on failure.
 */
-bool aalineColor(SDL_Renderer * renderer, Sint16 x1, Sint16 y1, Sint16 x2, Sint16 y2, Uint32 color)
+bool aalineColor(SDL_Renderer * renderer, float x1, float y1, float x2, float y2, Uint32 color)
 {
 	Uint8 *c = (Uint8 *)&color; 
 	return _aalineRGBA(renderer, x1, y1, x2, y2, c[0], c[1], c[2], c[3], 1);
@@ -1091,9 +1086,9 @@ bool aalineColor(SDL_Renderer * renderer, Sint16 x1, Sint16 y1, Sint16 x2, Sint1
 
 \returns Returns true on success, false on failure.
 */
-bool aalineRGBA(SDL_Renderer * renderer, Sint16 x1, Sint16 y1, Sint16 x2, Sint16 y2, Uint8 r, Uint8 g, Uint8 b, Uint8 a)
+bool aalineRGBA(SDL_Renderer * renderer, float x1, float y1, float x2, float y2, Uint8 r, Uint8 g, Uint8 b, Uint8 a)
 {
-	return _aalineRGBA(renderer, x1, y1, x2, y2, r, g, b, a, 1);
+	return _aalineRGBA(renderer, x1, y1, x2, y2, r, g, b, a, true);
 }
 
 /* ----- Circle */
@@ -1109,7 +1104,7 @@ bool aalineRGBA(SDL_Renderer * renderer, Sint16 x1, Sint16 y1, Sint16 x2, Sint16
 
 \returns Returns true on success, false on failure.
 */
-bool circleColor(SDL_Renderer * renderer, Sint16 x, Sint16 y, Sint16 rad, Uint32 color)
+bool circleColor(SDL_Renderer * renderer, float x, float y, float rad, Uint32 color)
 {
 	Uint8 *c = (Uint8 *)&color; 
 	return ellipseRGBA(renderer, x, y, rad, rad, c[0], c[1], c[2], c[3]);
@@ -1129,7 +1124,7 @@ bool circleColor(SDL_Renderer * renderer, Sint16 x, Sint16 y, Sint16 rad, Uint32
 
 \returns Returns true on success, false on failure.
 */
-bool circleRGBA(SDL_Renderer * renderer, Sint16 x, Sint16 y, Sint16 rad, Uint8 r, Uint8 g, Uint8 b, Uint8 a)
+bool circleRGBA(SDL_Renderer * renderer, float x, float y, float rad, Uint8 r, Uint8 g, Uint8 b, Uint8 a)
 {
 	return ellipseRGBA(renderer, x, y, rad, rad, r, g, b, a);
 }
@@ -1149,7 +1144,7 @@ bool circleRGBA(SDL_Renderer * renderer, Sint16 x, Sint16 y, Sint16 rad, Uint8 r
 
 \returns Returns true on success, false on failure.
 */
-bool arcColor(SDL_Renderer * renderer, Sint16 x, Sint16 y, Sint16 rad, Sint16 start, Sint16 end, Uint32 color)
+bool arcColor(SDL_Renderer * renderer, float x, float y, float rad, int start, int end, Uint32 color)
 {
 	Uint8 *c = (Uint8 *)&color; 
 	return arcRGBA(renderer, x, y, rad, start, end, c[0], c[1], c[2], c[3]);
@@ -1172,16 +1167,16 @@ bool arcColor(SDL_Renderer * renderer, Sint16 x, Sint16 y, Sint16 rad, Sint16 st
 \returns Returns true on success, false on failure.
 */
 /* TODO: rewrite algorithm; arc endpoints are not always drawn */
-bool arcRGBA(SDL_Renderer * renderer, Sint16 x, Sint16 y, Sint16 rad, Sint16 start, Sint16 end, Uint8 r, Uint8 g, Uint8 b, Uint8 a)
+bool arcRGBA(SDL_Renderer * renderer, float x, float y, float rad, int start, int end, Uint8 r, Uint8 g, Uint8 b, Uint8 a)
 {
 	bool result;
-	Sint16 cx = 0;
-	Sint16 cy = rad;
-	Sint16 df = 1 - rad;
-	Sint16 d_e = 3;
-	Sint16 d_se = -2 * rad + 5;
-	Sint16 xpcx, xmcx, xpcy, xmcy;
-	Sint16 ypcy, ymcy, ypcx, ymcx;
+	float cx = 0;
+	float cy = rad;
+	float df = 1 - rad;
+	float d_e = 3;
+	float d_se = -2 * rad + 5;
+	float xpcx, xmcx, xpcy, xmcy;
+	float ypcy, ymcy, ypcx, ymcx;
 	Uint8 drawoct;
 	int startoct, endoct, oct, stopval_start = 0, stopval_end = 0;
 	double dstart, dend, temp = 0.;
@@ -1261,6 +1256,8 @@ bool arcRGBA(SDL_Renderer * renderer, Sint16 x, Sint16 y, Sint16 rad, Sint16 sta
 			case 7:
 				temp = -sin(dstart * M_PI / 180.);
 				break;
+			default:
+				break;
 			}
 			temp *= rad;
 			stopval_start = (int)temp;
@@ -1294,6 +1291,8 @@ bool arcRGBA(SDL_Renderer * renderer, Sint16 x, Sint16 y, Sint16 rad, Sint16 sta
 			case 4:
 			case 7:
 				temp = -sin(dend * M_PI / 180);
+				break;
+			default:
 				break;
 			}
 			temp *= rad;
@@ -1407,7 +1406,7 @@ bool arcRGBA(SDL_Renderer * renderer, Sint16 x, Sint16 y, Sint16 rad, Sint16 sta
 
 \returns Returns true on success, false on failure.
 */
-bool aacircleColor(SDL_Renderer * renderer, Sint16 x, Sint16 y, Sint16 rad, Uint32 color)
+bool aacircleColor(SDL_Renderer * renderer, float x, float y, float rad, Uint32 color)
 {
 	Uint8 *c = (Uint8 *)&color; 
 	return aaellipseRGBA(renderer, x, y, rad, rad, c[0], c[1], c[2], c[3]);
@@ -1427,7 +1426,7 @@ bool aacircleColor(SDL_Renderer * renderer, Sint16 x, Sint16 y, Sint16 rad, Uint
 
 \returns Returns true on success, false on failure.
 */
-bool aacircleRGBA(SDL_Renderer * renderer, Sint16 x, Sint16 y, Sint16 rad, Uint8 r, Uint8 g, Uint8 b, Uint8 a)
+bool aacircleRGBA(SDL_Renderer * renderer, float x, float y, float rad, Uint8 r, Uint8 g, Uint8 b, Uint8 a)
 {
 	/*
 	* Draw 
@@ -1449,11 +1448,11 @@ bool aacircleRGBA(SDL_Renderer * renderer, Sint16 x, Sint16 y, Sint16 rad, Uint8
 
 \returns Returns true on success, false on failure.
 */
-int _drawQuadrants(SDL_Renderer * renderer,  Sint16 x, Sint16 y, Sint16 dx, Sint16 dy, Sint32 f)
+bool _drawQuadrants(SDL_Renderer * renderer,  float x, float y, float dx, float dy, bool f)
 {
 	bool result = true;
-	Sint16 xpdx, xmdx;
-	Sint16 ypdy, ymdy;
+	float xpdx, xmdx;
+	float ypdy, ymdy;
 
 	if (dx == 0) {
 		if (dy == 0) {
@@ -1504,16 +1503,16 @@ int _drawQuadrants(SDL_Renderer * renderer,  Sint16 x, Sint16 y, Sint16 dx, Sint
 \returns Returns true on success, false on failure.
 */
 #define DEFAULT_ELLIPSE_OVERSCAN	4
-bool _ellipseRGBA(SDL_Renderer * renderer, Sint16 x, Sint16 y, Sint16 rx, Sint16 ry, Uint8 r, Uint8 g, Uint8 b, Uint8 a, Sint32 f)
+bool _ellipseRGBA(SDL_Renderer * renderer, float x, float y, float rx, float ry, Uint8 r, Uint8 g, Uint8 b, Uint8 a, bool f)
 {
 	bool result;
-	Sint32 rxi, ryi;
-	Sint32 rx2, ry2, rx22, ry22; 
-    Sint32 error;
-    Sint32 curX, curY, curXp1, curYm1;
-	Sint32 scrX, scrY, oldX, oldY;
-    Sint32 deltaX, deltaY;
-	Sint32 ellipseOverscan;
+	float rxi, ryi;
+	float rx2, ry2, rx22, ry22;
+    int error;
+    float curX, curY, curXp1, curYm1;
+	int scrX, scrY, oldX, oldY;
+    int deltaX, deltaY;
+	int ellipseOverscan;
 
 	/*
 	* Sanity check radii 
@@ -1666,7 +1665,7 @@ bool _ellipseRGBA(SDL_Renderer * renderer, Sint16 x, Sint16 y, Sint16 rx, Sint16
 
 \returns Returns true on success, false on failure.
 */
-bool ellipseColor(SDL_Renderer * renderer, Sint16 x, Sint16 y, Sint16 rx, Sint16 ry, Uint32 color)
+bool ellipseColor(SDL_Renderer * renderer, float x, float y, float rx, float ry, Uint32 color)
 {
 	Uint8 *c = (Uint8 *)&color; 
 	return _ellipseRGBA(renderer, x, y, rx, ry, c[0], c[1], c[2], c[3], 0);
@@ -1687,7 +1686,7 @@ bool ellipseColor(SDL_Renderer * renderer, Sint16 x, Sint16 y, Sint16 rx, Sint16
 
 \returns Returns true on success, false on failure.
 */
-bool ellipseRGBA(SDL_Renderer * renderer, Sint16 x, Sint16 y, Sint16 rx, Sint16 ry, Uint8 r, Uint8 g, Uint8 b, Uint8 a)
+bool ellipseRGBA(SDL_Renderer * renderer, float x, float y, float rx, float ry, Uint8 r, Uint8 g, Uint8 b, Uint8 a)
 {
 	return _ellipseRGBA(renderer, x, y, rx, ry, r, g, b, a, 0);
 }
@@ -1705,7 +1704,7 @@ bool ellipseRGBA(SDL_Renderer * renderer, Sint16 x, Sint16 y, Sint16 rx, Sint16 
 
 \returns Returns true on success, false on failure.
 */
-bool filledCircleColor(SDL_Renderer * renderer, Sint16 x, Sint16 y, Sint16 rad, Uint32 color)
+bool filledCircleColor(SDL_Renderer * renderer, float x, float y, float rad, Uint32 color)
 {
 	Uint8 *c = (Uint8 *)&color; 
 	return filledEllipseRGBA(renderer, x, y, rad, rad, c[0], c[1], c[2], c[3]);
@@ -1725,7 +1724,7 @@ bool filledCircleColor(SDL_Renderer * renderer, Sint16 x, Sint16 y, Sint16 rad, 
 
 \returns Returns true on success, false on failure.
 */
-bool filledCircleRGBA(SDL_Renderer * renderer, Sint16 x, Sint16 y, Sint16 rad, Uint8 r, Uint8 g, Uint8 b, Uint8 a)
+bool filledCircleRGBA(SDL_Renderer * renderer, float x, float y, float rad, Uint8 r, Uint8 g, Uint8 b, Uint8 a)
 {
 	return _ellipseRGBA(renderer, x, y, rad, rad, r, g ,b, a, 1);
 }
@@ -1785,7 +1784,7 @@ __declspec(naked) long int
 
 \returns Returns true on success, false on failure.
 */
-bool aaellipseColor(SDL_Renderer * renderer, Sint16 x, Sint16 y, Sint16 rx, Sint16 ry, Uint32 color)
+bool aaellipseColor(SDL_Renderer * renderer, float x, float y, float rx, float ry, Uint32 color)
 {
 	Uint8 *c = (Uint8 *)&color; 
 	return aaellipseRGBA(renderer, x, y, rx, ry, c[0], c[1], c[2], c[3]);
@@ -1806,12 +1805,12 @@ bool aaellipseColor(SDL_Renderer * renderer, Sint16 x, Sint16 y, Sint16 rx, Sint
 
 \returns Returns true on success, false on failure.
 */
-bool aaellipseRGBA(SDL_Renderer * renderer, Sint16 x, Sint16 y, Sint16 rx, Sint16 ry, Uint8 r, Uint8 g, Uint8 b, Uint8 a)
+bool aaellipseRGBA(SDL_Renderer * renderer, float x, float y, float rx, float ry, Uint8 r, Uint8 g, Uint8 b, Uint8 a)
 {
 	bool result;
 	int i;
 	int a2, b2, ds, dt, dxt, t, s, d;
-	Sint16 xp, yp, xs, ys, dyt, od, xx, yy, xc2, yc2;
+	float xp, yp, xs, ys, dyt, od, xx, yy, xc2, yc2;
 	float cp;
 	double sab;
 	Uint8 weight, iweight;
@@ -1849,8 +1848,8 @@ bool aaellipseRGBA(SDL_Renderer * renderer, Sint16 x, Sint16 y, Sint16 rx, Sint1
 	yc2 = 2 * y;
 
 	sab = sqrt((double)(a2 + b2));
-	od = (Sint16)lrint(sab*0.01) + 1; /* introduce some overdraw */
-	dxt = (Sint16)lrint((double)a2 / sab) + od;
+	od = (float)lrint(sab*0.01) + 1; /* introduce some overdraw */
+	dxt = (float)lrint((double)a2 / sab) + od;
 
 	t = 0;
 	s = -2 * a2 * ry;
@@ -1926,7 +1925,7 @@ bool aaellipseRGBA(SDL_Renderer * renderer, Sint16 x, Sint16 y, Sint16 rx, Sint1
 	}
 
 	/* Replaces original approximation code dyt = abs(yp - yc); */
-	dyt = (Sint16)lrint((double)b2 / sab ) + od;    
+	dyt = (float)lrint((double)b2 / sab ) + od;
 
 	for (i = 1; i <= dyt; i++) {
 		yp++;
@@ -2001,7 +2000,7 @@ bool aaellipseRGBA(SDL_Renderer * renderer, Sint16 x, Sint16 y, Sint16 rx, Sint1
 
 \returns Returns true on success, false on failure.
 */
-bool filledEllipseColor(SDL_Renderer * renderer, Sint16 x, Sint16 y, Sint16 rx, Sint16 ry, Uint32 color)
+bool filledEllipseColor(SDL_Renderer * renderer, float x, float y, float rx, float ry, Uint32 color)
 {
 	Uint8 *c = (Uint8 *)&color; 
 	return _ellipseRGBA(renderer, x, y, rx, ry, c[0], c[1], c[2], c[3], 1);
@@ -2022,7 +2021,7 @@ bool filledEllipseColor(SDL_Renderer * renderer, Sint16 x, Sint16 y, Sint16 rx, 
 
 \returns Returns true on success, false on failure.
 */
-bool filledEllipseRGBA(SDL_Renderer * renderer, Sint16 x, Sint16 y, Sint16 rx, Sint16 ry, Uint8 r, Uint8 g, Uint8 b, Uint8 a)
+bool filledEllipseRGBA(SDL_Renderer * renderer, float x, float y, float rx, float ry, Uint8 r, Uint8 g, Uint8 b, Uint8 a)
 {
 	return _ellipseRGBA(renderer, x, y, rx, ry, r, g, b, a, 1);
 }
@@ -2049,14 +2048,14 @@ Note: Determines vertex array and uses polygon or filledPolygon drawing routines
 \returns Returns true on success, false on failure.
 */
 /* TODO: rewrite algorithm; pie is not always accurate */
-bool _pieRGBA(SDL_Renderer * renderer, Sint16 x, Sint16 y, Sint16 rad, Sint16 start, Sint16 end,  Uint8 r, Uint8 g, Uint8 b, Uint8 a, Uint8 filled)
+bool _pieRGBA(SDL_Renderer * renderer, float x, float y, float rad, int start, int end,  Uint8 r, Uint8 g, Uint8 b, Uint8 a, bool filled)
 {
 	bool result;
 	double angle, start_angle, end_angle;
 	double deltaAngle;
 	double dr;
 	int numpoints, i;
-	Sint16 *vx, *vy;
+	float *vx, *vy;
 
 	/*
 	* Sanity check radii 
@@ -2100,7 +2099,7 @@ bool _pieRGBA(SDL_Renderer * renderer, Sint16 x, Sint16 y, Sint16 rad, Sint16 st
 	}
 
 	/* Allocate combined vertex array */
-	vx = vy = (Sint16 *) malloc(2 * sizeof(Uint16) * numpoints);
+	vx = vy = (float *) malloc(2 * sizeof(float) * numpoints);
 	if (vx == NULL) {
 		return (false);
 	}
@@ -2164,8 +2163,8 @@ bool _pieRGBA(SDL_Renderer * renderer, Sint16 x, Sint16 y, Sint16 rad, Sint16 st
 
 \returns Returns true on success, false on failure.
 */
-bool pieColor(SDL_Renderer * renderer, Sint16 x, Sint16 y, Sint16 rad, 
-	Sint16 start, Sint16 end, Uint32 color) 
+bool pieColor(SDL_Renderer * renderer, float x, float y, float rad,
+	int start, int end, Uint32 color)
 {
 	Uint8 *c = (Uint8 *)&color; 
 	return _pieRGBA(renderer, x, y, rad, start, end, c[0], c[1], c[2], c[3], 0);
@@ -2187,8 +2186,8 @@ bool pieColor(SDL_Renderer * renderer, Sint16 x, Sint16 y, Sint16 rad,
 
 \returns Returns true on success, false on failure.
 */
-bool pieRGBA(SDL_Renderer * renderer, Sint16 x, Sint16 y, Sint16 rad,
-	Sint16 start, Sint16 end, Uint8 r, Uint8 g, Uint8 b, Uint8 a)
+bool pieRGBA(SDL_Renderer * renderer, float x, float y, float rad,
+	int start, int end, Uint8 r, Uint8 g, Uint8 b, Uint8 a)
 {
 	return _pieRGBA(renderer, x, y, rad, start, end, r, g, b, a, 0);
 }
@@ -2206,7 +2205,7 @@ bool pieRGBA(SDL_Renderer * renderer, Sint16 x, Sint16 y, Sint16 rad,
 
 \returns Returns true on success, false on failure.
 */
-bool filledPieColor(SDL_Renderer * renderer, Sint16 x, Sint16 y, Sint16 rad, Sint16 start, Sint16 end, Uint32 color)
+bool filledPieColor(SDL_Renderer * renderer, float x, float y, float rad, int start, int end, Uint32 color)
 {
 	Uint8 *c = (Uint8 *)&color; 
 	return _pieRGBA(renderer, x, y, rad, start, end, c[0], c[1], c[2], c[3], 1);
@@ -2228,8 +2227,8 @@ bool filledPieColor(SDL_Renderer * renderer, Sint16 x, Sint16 y, Sint16 rad, Sin
 
 \returns Returns true on success, false on failure.
 */
-bool filledPieRGBA(SDL_Renderer * renderer, Sint16 x, Sint16 y, Sint16 rad,
-	Sint16 start, Sint16 end, Uint8 r, Uint8 g, Uint8 b, Uint8 a)
+bool filledPieRGBA(SDL_Renderer * renderer, float x, float y, float rad,
+	int start, int end, Uint8 r, Uint8 g, Uint8 b, Uint8 a)
 {
 	return _pieRGBA(renderer, x, y, rad, start, end, r, g, b, a, 1);
 }
@@ -2252,10 +2251,10 @@ Note: Creates vertex array and uses polygon routine to render.
 
 \returns Returns true on success, false on failure.
 */
-bool trigonColor(SDL_Renderer * renderer, Sint16 x1, Sint16 y1, Sint16 x2, Sint16 y2, Sint16 x3, Sint16 y3, Uint32 color)
+bool trigonColor(SDL_Renderer * renderer, float x1, float y1, float x2, float y2, float x3, float y3, Uint32 color)
 {
-	Sint16 vx[3]; 
-	Sint16 vy[3];
+	float vx[3];
+	float vy[3];
 
 	vx[0]=x1;
 	vx[1]=x2;
@@ -2284,11 +2283,11 @@ bool trigonColor(SDL_Renderer * renderer, Sint16 x1, Sint16 y1, Sint16 x2, Sint1
 
 \returns Returns true on success, false on failure.
 */
-bool trigonRGBA(SDL_Renderer * renderer, Sint16 x1, Sint16 y1, Sint16 x2, Sint16 y2, Sint16 x3, Sint16 y3,
+bool trigonRGBA(SDL_Renderer * renderer, float x1, float y1, float x2, float y2, float x3, float y3,
 	Uint8 r, Uint8 g, Uint8 b, Uint8 a)
 {
-	Sint16 vx[3]; 
-	Sint16 vy[3];
+	float vx[3];
+	float vy[3];
 
 	vx[0]=x1;
 	vx[1]=x2;
@@ -2318,10 +2317,10 @@ Note: Creates vertex array and uses aapolygon routine to render.
 
 \returns Returns true on success, false on failure.
 */
-bool aatrigonColor(SDL_Renderer * renderer, Sint16 x1, Sint16 y1, Sint16 x2, Sint16 y2, Sint16 x3, Sint16 y3, Uint32 color)
+bool aatrigonColor(SDL_Renderer * renderer, float x1, float y1, float x2, float y2, float x3, float y3, Uint32 color)
 {
-	Sint16 vx[3]; 
-	Sint16 vy[3];
+	float vx[3];
+	float vy[3];
 
 	vx[0]=x1;
 	vx[1]=x2;
@@ -2350,11 +2349,11 @@ bool aatrigonColor(SDL_Renderer * renderer, Sint16 x1, Sint16 y1, Sint16 x2, Sin
 
 \returns Returns true on success, false on failure.
 */
-bool aatrigonRGBA(SDL_Renderer * renderer,  Sint16 x1, Sint16 y1, Sint16 x2, Sint16 y2, Sint16 x3, Sint16 y3,
+bool aatrigonRGBA(SDL_Renderer * renderer,  float x1, float y1, float x2, float y2, float x3, float y3,
 	Uint8 r, Uint8 g, Uint8 b, Uint8 a)
 {
-	Sint16 vx[3]; 
-	Sint16 vy[3];
+	float vx[3];
+	float vy[3];
 
 	vx[0]=x1;
 	vx[1]=x2;
@@ -2384,10 +2383,10 @@ Note: Creates vertex array and uses aapolygon routine to render.
 
 \returns Returns true on success, false on failure.
 */
-bool filledTrigonColor(SDL_Renderer * renderer, Sint16 x1, Sint16 y1, Sint16 x2, Sint16 y2, Sint16 x3, Sint16 y3, Uint32 color)
+bool filledTrigonColor(SDL_Renderer * renderer, float x1, float y1, float x2, float y2, float x3, float y3, Uint32 color)
 {
-	Sint16 vx[3]; 
-	Sint16 vy[3];
+	float vx[3];
+	float vy[3];
 
 	vx[0]=x1;
 	vx[1]=x2;
@@ -2418,11 +2417,11 @@ Note: Creates vertex array and uses aapolygon routine to render.
 
 \returns Returns true on success, false on failure.
 */
-bool filledTrigonRGBA(SDL_Renderer * renderer, Sint16 x1, Sint16 y1, Sint16 x2, Sint16 y2, Sint16 x3, Sint16 y3,
+bool filledTrigonRGBA(SDL_Renderer * renderer, float x1, float y1, float x2, float y2, float x3, float y3,
 	Uint8 r, Uint8 g, Uint8 b, Uint8 a)
 {
-	Sint16 vx[3]; 
-	Sint16 vy[3];
+	float vx[3];
+	float vy[3];
 
 	vx[0]=x1;
 	vx[1]=x2;
@@ -2447,7 +2446,7 @@ bool filledTrigonRGBA(SDL_Renderer * renderer, Sint16 x1, Sint16 y1, Sint16 x2, 
 
 \returns Returns true on success, false on failure.
 */
-bool polygonColor(SDL_Renderer * renderer, const Sint16 * vx, const Sint16 * vy, int n, Uint32 color)
+bool polygonColor(SDL_Renderer * renderer, const float * vx, const float * vy, int n, Uint32 color)
 {
 	Uint8 *c = (Uint8 *)&color; 
 	return polygonRGBA(renderer, vx, vy, n, c[0], c[1], c[2], c[3]);
@@ -2463,7 +2462,7 @@ bool polygonColor(SDL_Renderer * renderer, const Sint16 * vx, const Sint16 * vy,
 
 \returns Returns true on success, false on failure.
 */
-bool polygon(SDL_Renderer * renderer, const Sint16 * vx, const Sint16 * vy, int n)
+bool polygon(SDL_Renderer * renderer, const float * vx, const float * vy, int n)
 {
 	/*
 	* Draw 
@@ -2529,13 +2528,13 @@ bool polygon(SDL_Renderer * renderer, const Sint16 * vx, const Sint16 * vy, int 
 
 \returns Returns true on success, false on failure.
 */
-bool polygonRGBA(SDL_Renderer * renderer, const Sint16 * vx, const Sint16 * vy, int n, Uint8 r, Uint8 g, Uint8 b, Uint8 a)
+bool polygonRGBA(SDL_Renderer * renderer, const float * vx, const float * vy, int n, Uint8 r, Uint8 g, Uint8 b, Uint8 a)
 {
 	/*
 	* Draw 
 	*/
 	bool result;
-	const Sint16 *x1, *y1, *x2, *y2;
+	const float *x1, *y1, *x2, *y2;
 
 	/*
 	* Vertex array NULL check 
@@ -2590,7 +2589,7 @@ bool polygonRGBA(SDL_Renderer * renderer, const Sint16 * vx, const Sint16 * vy, 
 
 \returns Returns true on success, false on failure.
 */
-bool aapolygonColor(SDL_Renderer * renderer, const Sint16 * vx, const Sint16 * vy, int n, Uint32 color)
+bool aapolygonColor(SDL_Renderer * renderer, const float * vx, const float * vy, int n, Uint32 color)
 {
 	Uint8 *c = (Uint8 *)&color; 
 	return aapolygonRGBA(renderer, vx, vy, n, c[0], c[1], c[2], c[3]);
@@ -2610,11 +2609,11 @@ bool aapolygonColor(SDL_Renderer * renderer, const Sint16 * vx, const Sint16 * v
 
 \returns Returns true on success, false on failure.
 */
-bool aapolygonRGBA(SDL_Renderer * renderer, const Sint16 * vx, const Sint16 * vy, int n, Uint8 r, Uint8 g, Uint8 b, Uint8 a)
+bool aapolygonRGBA(SDL_Renderer * renderer, const float * vx, const float * vy, int n, Uint8 r, Uint8 g, Uint8 b, Uint8 a)
 {
 	bool result;
 	int i;
-	const Sint16 *x1, *y1, *x2, *y2;
+	const float *x1, *y1, *x2, *y2;
 
 	/*
 	* Vertex array NULL check 
@@ -2685,7 +2684,7 @@ static int *gfxPrimitivesPolyIntsGlobal = NULL;
 
 Note: Used for non-multithreaded (default) operation of filledPolygonMT.
 */
-static int gfxPrimitivesPolyAllocatedGlobal = 0;
+static bool gfxPrimitivesPolyAllocatedGlobal = false;
 
 /*!
 \brief Draw filled polygon with alpha blending (multi-threaded capable).
@@ -2705,7 +2704,7 @@ Note: The last two parameters are optional; but are required for multithreaded o
 
 \returns Returns true on success, false on failure.
 */
-int filledPolygonRGBAMT(SDL_Renderer * renderer, const Sint16 * vx, const Sint16 * vy, int n, Uint8 r, Uint8 g, Uint8 b, Uint8 a, int **polyInts, int *polyAllocated)
+bool filledPolygonRGBAMT(SDL_Renderer * renderer, const float * vx, const float * vy, int n, Uint8 r, Uint8 g, Uint8 b, Uint8 a, int **polyInts, bool *polyAllocated)
 {
 	bool result;
 	int i;
@@ -2717,7 +2716,7 @@ int filledPolygonRGBAMT(SDL_Renderer * renderer, const Sint16 * vx, const Sint16
 	int ints;
 	int *gfxPrimitivesPolyInts = NULL;
 	int *gfxPrimitivesPolyIntsNew = NULL;
-	int gfxPrimitivesPolyAllocated = 0;
+	bool gfxPrimitivesPolyAllocated = false;
 
 	/*
 	* Vertex array NULL check 
@@ -2792,8 +2791,8 @@ int filledPolygonRGBAMT(SDL_Renderer * renderer, const Sint16 * vx, const Sint16
 	/*
 	* Check temp array again
 	*/
-	if (gfxPrimitivesPolyInts==NULL) {        
-		return(false);
+	if (gfxPrimitivesPolyInts==NULL) {
+		return false;
 	}
 
 	/*
@@ -2846,8 +2845,8 @@ int filledPolygonRGBAMT(SDL_Renderer * renderer, const Sint16 * vx, const Sint16
 		* Set color 
 		*/
 		result = true;
-	   result &= SDL_SetRenderDrawBlendMode(renderer, (a == 255) ? SDL_BLENDMODE_NONE : SDL_BLENDMODE_BLEND);
-		result &= SDL_SetRenderDrawColor(renderer, r, g, b, a);	
+	    result &= SDL_SetRenderDrawBlendMode(renderer, (a == 255) ? SDL_BLENDMODE_NONE : SDL_BLENDMODE_BLEND);
+		result &= SDL_SetRenderDrawColor(renderer, r, g, b, a);
 
 		for (i = 0; (i < ints); i += 2) {
 			xa = gfxPrimitivesPolyInts[i] + 1;
@@ -2858,7 +2857,7 @@ int filledPolygonRGBAMT(SDL_Renderer * renderer, const Sint16 * vx, const Sint16
 		}
 	}
 
-	return (result);
+	return result;
 }
 
 /*!
@@ -2872,7 +2871,7 @@ int filledPolygonRGBAMT(SDL_Renderer * renderer, const Sint16 * vx, const Sint16
 
 \returns Returns true on success, false on failure.
 */
-bool filledPolygonColor(SDL_Renderer * renderer, const Sint16 * vx, const Sint16 * vy, int n, Uint32 color)
+bool filledPolygonColor(SDL_Renderer * renderer, const float * vx, const float * vy, int n, Uint32 color)
 {
 	Uint8 *c = (Uint8 *)&color; 
 	return filledPolygonRGBAMT(renderer, vx, vy, n, c[0], c[1], c[2], c[3], NULL, NULL);
@@ -2892,7 +2891,7 @@ bool filledPolygonColor(SDL_Renderer * renderer, const Sint16 * vx, const Sint16
 
 \returns Returns true on success, false on failure.
 */
-bool filledPolygonRGBA(SDL_Renderer * renderer, const Sint16 * vx, const Sint16 * vy, int n, Uint8 r, Uint8 g, Uint8 b, Uint8 a)
+bool filledPolygonRGBA(SDL_Renderer * renderer, const float * vx, const float * vy, int n, Uint8 r, Uint8 g, Uint8 b, Uint8 a)
 {
 	return filledPolygonRGBAMT(renderer, vx, vy, n, r, g, b, a, NULL, NULL);
 }
@@ -2914,10 +2913,10 @@ bool filledPolygonRGBA(SDL_Renderer * renderer, const Sint16 * vx, const Sint16 
 
 \returns Returns true on success, false on failure.
 */
-bool _HLineTextured(SDL_Renderer *renderer, Sint16 x1, Sint16 x2, Sint16 y, SDL_Texture *texture, int texture_w, int texture_h, int texture_dx, int texture_dy)
+bool _HLineTextured(SDL_Renderer *renderer, float x1, float x2, float y, SDL_Texture *texture, int texture_w, int texture_h, int texture_dx, int texture_dy)
 {
-	Sint16 w;
-	Sint16 xtmp;
+	float w;
+	float xtmp;
 	bool result = true;
 	int texture_x_walker;    
 	int texture_y_start;    
@@ -2941,12 +2940,12 @@ bool _HLineTextured(SDL_Renderer *renderer, Sint16 x1, Sint16 x2, Sint16 y, SDL_
 	/*
 	* Determine where in the texture we start drawing
 	*/
-	texture_x_walker =   (x1 - texture_dx)  % texture_w;
+	texture_x_walker = ((int)x1 - texture_dx)  % texture_w;
 	if (texture_x_walker < 0){
 		texture_x_walker = texture_w + texture_x_walker ;
 	}
 
-	texture_y_start = (y + texture_dy) % texture_h;
+	texture_y_start = ((int)y + texture_dy) % texture_h;
 	if (texture_y_start < 0){
 		texture_y_start = texture_h + texture_y_start;
 	}
@@ -3013,8 +3012,8 @@ to the left and want the texture to apear the same you need to increase the text
 
 \returns Returns true on success, false on failure.
 */
-bool texturedPolygonMT(SDL_Renderer *renderer, const Sint16 * vx, const Sint16 * vy, int n, 
-	SDL_Surface * texture, int texture_dx, int texture_dy, int **polyInts, int *polyAllocated)
+bool texturedPolygonMT(SDL_Renderer *renderer, const float * vx, const float * vy, int n,
+	SDL_Surface * texture, int texture_dx, int texture_dy, int **polyInts, bool *polyAllocated)
 {
 	bool result;
 	int i;
@@ -3089,7 +3088,7 @@ bool texturedPolygonMT(SDL_Renderer *renderer, const Sint16 * vx, const Sint16 *
 	* Check temp array again
 	*/
 	if (gfxPrimitivesPolyInts==NULL) {        
-		return(false);
+		return false;
 	}
 
 	/*
@@ -3165,7 +3164,7 @@ bool texturedPolygonMT(SDL_Renderer *renderer, const Sint16 * vx, const Sint16 *
 
 	SDL_DestroyTexture(textureAsTexture);
 
-	return (result);
+	return result;
 }
 
 /*!
@@ -3184,7 +3183,7 @@ to the left and want the texture to apear the same you need to increase the text
 
 \returns Returns true on success, false on failure.
 */
-bool texturedPolygon(SDL_Renderer *renderer, const Sint16 * vx, const Sint16 * vy, int n, SDL_Surface *texture, int texture_dx, int texture_dy)
+bool texturedPolygon(SDL_Renderer *renderer, const float * vx, const float * vy, int n, SDL_Surface *texture, int texture_dx, int texture_dy)
 {
 	/*
 	* Draw
@@ -3207,37 +3206,37 @@ static const unsigned char *currentFontdata = gfxPrimitivesFontdata;
 /*!
 \brief Width of the current font. Default is 8. 
 */
-static Uint32 charWidth = 8;
+static unsigned int charWidth = 8;
 
 /*!
 \brief Height of the current font. Default is 8. 
 */
-static Uint32 charHeight = 8;
+static unsigned int charHeight = 8;
 
 /*!
 \brief Width for rendering. Autocalculated.
 */
-static Uint32 charWidthLocal = 8;
+static unsigned int charWidthLocal = 8;
 
 /*!
 \brief Height for rendering. Autocalculated.
 */
-static Uint32 charHeightLocal = 8;
+static unsigned int charHeightLocal = 8;
 
 /*!
 \brief Pitch of the current font in bytes. Default is 1. 
 */
-static Uint32 charPitch = 1;
+static unsigned int charPitch = 1;
 
 /*!
 \brief Characters 90deg clockwise rotations. Default is 0. Max is 3. 
 */
-static Uint32 charRotation = 0;
+static unsigned int charRotation = 0;
 
 /*!
 \brief Character data size in bytes of the current font. Default is 8. 
 */
-static Uint32 charSize = 8;
+static unsigned int charSize = 8;
 
 /*!
 \brief Sets or resets the current global font data.
@@ -3252,7 +3251,7 @@ The font data array is organized in follows:
 \param cw Width of character in bytes. Ignored if fontdata==NULL.
 \param ch Height of character in bytes. Ignored if fontdata==NULL.
 */
-void gfxPrimitivesSetFont(const void *fontdata, Uint32 cw, Uint32 ch)
+void gfxPrimitivesSetFont(const void *fontdata, unsigned int cw, unsigned int ch)
 {
 	int i;
 
@@ -3298,7 +3297,7 @@ Changing the rotation, will reset the character cache.
 
 \param rotation Number of 90deg clockwise steps to rotate
 */
-void gfxPrimitivesSetFontRotation(Uint32 rotation)
+void gfxPrimitivesSetFontRotation(unsigned int rotation)
 {
 	int i;
 
@@ -3344,20 +3343,20 @@ void gfxPrimitivesSetFontRotation(Uint32 rotation)
 
 \returns Returns true on success, false on failure.
 */
-bool characterRGBA(SDL_Renderer *renderer, Sint16 x, Sint16 y, char c, Uint8 r, Uint8 g, Uint8 b, Uint8 a)
+bool characterRGBA(SDL_Renderer *renderer, float x, float y, char c, Uint8 r, Uint8 g, Uint8 b, Uint8 a)
 {
 	SDL_FRect srect;
 	SDL_FRect drect;
 	bool result;
-	Uint32 ix, iy;
+	unsigned int ix, iy;
 	const unsigned char *charpos;
 	Uint8 *curpos;
 	Uint8 patt, mask;
 	Uint8 *linepos;
-	Uint32 pitch;
+	unsigned int pitch;
 	SDL_Surface *character;
 	SDL_Surface *rotatedCharacter;
-	Uint32 ci;
+	unsigned int ci;
 
 	/*
 	* Setup source rectangle
@@ -3409,9 +3408,9 @@ bool characterRGBA(SDL_Renderer *renderer, Sint16 x, Sint16 y, char c, Uint8 r, 
 					mask = 0x80;
 				}
 				if (patt & mask) {
-					*(Uint32 *)curpos = 0xffffffff;
+					*(unsigned int *)curpos = 0xffffffff;
 				} else {
-					*(Uint32 *)curpos = 0;
+					*(unsigned int *)curpos = 0;
 				}
 				curpos += 4;
 			}
@@ -3465,7 +3464,7 @@ bool characterRGBA(SDL_Renderer *renderer, Sint16 x, Sint16 y, char c, Uint8 r, 
 
 \returns Returns true on success, false on failure.
 */
-bool characterColor(SDL_Renderer * renderer, Sint16 x, Sint16 y, char c, Uint32 color)
+bool characterColor(SDL_Renderer * renderer, float x, float y, char c, Uint32 color)
 {
 	Uint8 *co = (Uint8 *)&color; 
 	return characterRGBA(renderer, x, y, c, co[0], co[1], co[2], co[3]);
@@ -3486,7 +3485,7 @@ of the character width of the current global font.
 
 \returns Returns true on success, false on failure.
 */
-bool stringColor(SDL_Renderer * renderer, Sint16 x, Sint16 y, const char *s, Uint32 color)
+bool stringColor(SDL_Renderer * renderer, float x, float y, const char *s, Uint32 color)
 {
 	Uint8 *c = (Uint8 *)&color; 
 	return stringRGBA(renderer, x, y, s, c[0], c[1], c[2], c[3]);
@@ -3506,11 +3505,11 @@ bool stringColor(SDL_Renderer * renderer, Sint16 x, Sint16 y, const char *s, Uin
 
 \returns Returns true on success, false on failure.
 */
-bool stringRGBA(SDL_Renderer * renderer, Sint16 x, Sint16 y, const char *s, Uint8 r, Uint8 g, Uint8 b, Uint8 a)
+bool stringRGBA(SDL_Renderer * renderer, float x, float y, const char *s, Uint8 r, Uint8 g, Uint8 b, Uint8 a)
 {
 	bool result = true;
-	Sint16 curx = x;
-	Sint16 cury = y;
+	float curx = x;
+	float cury = y;
 	const char *curchar = s;
 
 	while (*curchar && result) {
@@ -3606,7 +3605,7 @@ double _evaluateBezier (double *data, int ndata, double t)
 
 \returns Returns true on success, false on failure.
 */
-bool bezierColor(SDL_Renderer * renderer, const Sint16 * vx, const Sint16 * vy, int n, int s, Uint32 color)
+bool bezierColor(SDL_Renderer * renderer, const float * vx, const float * vy, int n, int s, Uint32 color)
 {
 	Uint8 *c = (Uint8 *)&color; 
 	return bezierRGBA(renderer, vx, vy, n, s, c[0], c[1], c[2], c[3]);
@@ -3627,12 +3626,12 @@ bool bezierColor(SDL_Renderer * renderer, const Sint16 * vx, const Sint16 * vy, 
 
 \returns Returns true on success, false on failure.
 */
-bool bezierRGBA(SDL_Renderer * renderer, const Sint16 * vx, const Sint16 * vy, int n, int s, Uint8 r, Uint8 g, Uint8 b, Uint8 a)
+bool bezierRGBA(SDL_Renderer * renderer, const float * vx, const float * vy, int n, int s, Uint8 r, Uint8 g, Uint8 b, Uint8 a)
 {
 	bool result;
 	int i;
 	double *x, *y, t, stepsize;
-	Sint16 x1, y1, x2, y2;
+	float x1, y1, x2, y2;
 
 	/*
 	* Sanity check 
@@ -3675,12 +3674,12 @@ bool bezierRGBA(SDL_Renderer * renderer, const Sint16 * vx, const Sint16 * vy, i
 	* Draw 
 	*/
 	t=0.0;
-	x1=(Sint16)lrint(_evaluateBezier(x,n+1,t));
-	y1=(Sint16)lrint(_evaluateBezier(y,n+1,t));
+	x1=(float)lrint(_evaluateBezier(x,n+1,t));
+	y1=(float)lrint(_evaluateBezier(y,n+1,t));
 	for (i = 0; i <= (n*s); i++) {
 		t += stepsize;
-		x2=(Sint16)_evaluateBezier(x,n,t);
-		y2=(Sint16)_evaluateBezier(y,n,t);
+		x2=(float)_evaluateBezier(x,n,t);
+		y2=(float)_evaluateBezier(y,n,t);
 		result &= line(renderer, x1, y1, x2, y2);
 		x1 = x2;
 		y1 = y2;
@@ -3707,8 +3706,8 @@ bool bezierRGBA(SDL_Renderer * renderer, const Sint16 * vx, const Sint16 * vy, i
 
 \returns Returns true on success, false on failure.
 */
-bool thickLineColor(SDL_Renderer *renderer, Sint16 x1, Sint16 y1, Sint16 x2, Sint16 y2, Uint8 width, Uint32 color)
-{	
+bool thickLineColor(SDL_Renderer *renderer, float x1, float y1, float x2, float y2, Uint8 width, Uint32 color)
+{
 	Uint8 *c = (Uint8 *)&color; 
 	return thickLineRGBA(renderer, x1, y1, x2, y2, width, c[0], c[1], c[2], c[3]);
 }
@@ -3728,13 +3727,13 @@ bool thickLineColor(SDL_Renderer *renderer, Sint16 x1, Sint16 y1, Sint16 x2, Sin
 \param a The alpha value of the character to draw.
 
 \returns Returns true on success, false on failure.
-*/	
-bool thickLineRGBA(SDL_Renderer *renderer, Sint16 x1, Sint16 y1, Sint16 x2, Sint16 y2, Uint8 width, Uint8 r, Uint8 g, Uint8 b, Uint8 a)
+*/
+bool thickLineRGBA(SDL_Renderer *renderer, float x1, float y1, float x2, float y2, Uint8 width, Uint8 r, Uint8 g, Uint8 b, Uint8 a)
 {
 	int wh;
 	double dx, dy, dx1, dy1, dx2, dy2;
 	double l, wl2, nx, ny, ang, adj;
-	Sint16 px[4], py[4];
+	float px[4], py[4];
 
 	if (renderer == NULL) {
 		return false;
@@ -3770,14 +3769,14 @@ bool thickLineRGBA(SDL_Renderer *renderer, Sint16 x1, Sint16 y1, Sint16 x2, Sint
 	dy1 = (double)y1;
 	dx2 = (double)x2;
 	dy2 = (double)y2;
-	px[0] = (Sint16)(dx1 + ny);
-	px[1] = (Sint16)(dx1 - ny);
-	px[2] = (Sint16)(dx2 - ny);
-	px[3] = (Sint16)(dx2 + ny);
-	py[0] = (Sint16)(dy1 - nx);
-	py[1] = (Sint16)(dy1 + nx);
-	py[2] = (Sint16)(dy2 + nx);
-	py[3] = (Sint16)(dy2 - nx);
+	px[0] = (float)(dx1 + ny);
+	px[1] = (float)(dx1 - ny);
+	px[2] = (float)(dx2 - ny);
+	px[3] = (float)(dx2 + ny);
+	py[0] = (float)(dy1 - nx);
+	py[1] = (float)(dy1 + nx);
+	py[2] = (float)(dy2 + nx);
+	py[3] = (float)(dy2 - nx);
 
 	/* Draw polygon */
 	return filledPolygonRGBA(renderer, px, py, 4, r, g, b, a);

--- a/SDL3_gfxPrimitives.c
+++ b/SDL3_gfxPrimitives.c
@@ -104,12 +104,12 @@ bool pixelRGBA(SDL_Renderer * renderer, float x, float y, Uint8 r, Uint8 g, Uint
 
 \returns Returns true on success, false on failure.
 */
-bool pixelRGBAWeight(SDL_Renderer * renderer, float x, float y, Uint8 r, Uint8 g, Uint8 b, Uint8 a, unsigned int weight)
+bool pixelRGBAWeight(SDL_Renderer * renderer, float x, float y, Uint8 r, Uint8 g, Uint8 b, Uint8 a, Uint32 weight)
 {
 	/*
 	* Modify Alpha by weight 
 	*/
-	unsigned int ax = a;
+	Uint32 ax = a;
 	ax = ((ax * weight) >> 8);
 	if (ax > 255) {
 		a = 255;
@@ -366,7 +366,7 @@ bool roundedRectangleColor(SDL_Renderer * renderer, float x1, float y1, float x2
 */
 bool roundedRectangleRGBA(SDL_Renderer * renderer, float x1, float y1, float x2, float y2, float rad, Uint8 r, Uint8 g, Uint8 b, Uint8 a)
 {
-	int result = 0;
+	Sint32 result = 0;
 	float tmp;
 	float w, h;
 	float xx1, xx2;
@@ -860,9 +860,9 @@ bool _aalineRGBA(SDL_Renderer * renderer, float x1, float y1, float x2, float y2
 {
 	float xx0, yy0, xx1, yy1;
 	bool result;
-	unsigned int intshift, erracc, erradj;
-	unsigned int erracctmp, wgt;
-	int dx, dy, tmp, xdir, y0p1, x0pxdir;
+	Uint32 intshift, erracc, erradj;
+	Uint32 erracctmp, wgt;
+	Sint32 dx, dy, tmp, xdir, y0p1, x0pxdir;
 
 	/*
 	* Keep on working with 32bit numbers 
@@ -1144,7 +1144,7 @@ bool circleRGBA(SDL_Renderer * renderer, float x, float y, float rad, Uint8 r, U
 
 \returns Returns true on success, false on failure.
 */
-bool arcColor(SDL_Renderer * renderer, float x, float y, float rad, int start, int end, Uint32 color)
+bool arcColor(SDL_Renderer * renderer, float x, float y, float rad, Sint32 start, Sint32 end, Uint32 color)
 {
 	Uint8 *c = (Uint8 *)&color; 
 	return arcRGBA(renderer, x, y, rad, start, end, c[0], c[1], c[2], c[3]);
@@ -1167,7 +1167,7 @@ bool arcColor(SDL_Renderer * renderer, float x, float y, float rad, int start, i
 \returns Returns true on success, false on failure.
 */
 /* TODO: rewrite algorithm; arc endpoints are not always drawn */
-bool arcRGBA(SDL_Renderer * renderer, float x, float y, float rad, int start, int end, Uint8 r, Uint8 g, Uint8 b, Uint8 a)
+bool arcRGBA(SDL_Renderer * renderer, float x, float y, float rad, Sint32 start, Sint32 end, Uint8 r, Uint8 g, Uint8 b, Uint8 a)
 {
 	bool result;
 	float cx = 0;
@@ -1178,7 +1178,7 @@ bool arcRGBA(SDL_Renderer * renderer, float x, float y, float rad, int start, in
 	float xpcx, xmcx, xpcy, xmcy;
 	float ypcy, ymcy, ypcx, ymcx;
 	Uint8 drawoct;
-	int startoct, endoct, oct, stopval_start = 0, stopval_end = 0;
+	Sint32 startoct, endoct, oct, stopval_start = 0, stopval_end = 0;
 	double dstart, dend, temp = 0.;
 
 	/*
@@ -1508,11 +1508,11 @@ bool _ellipseRGBA(SDL_Renderer * renderer, float x, float y, float rx, float ry,
 	bool result;
 	float rxi, ryi;
 	float rx2, ry2, rx22, ry22;
-    int error;
+    Sint32 error;
     float curX, curY, curXp1, curYm1;
-	int scrX, scrY, oldX, oldY;
-    int deltaX, deltaY;
-	int ellipseOverscan;
+	Sint32 scrX, scrY, oldX, oldY;
+    Sint32 deltaX, deltaY;
+	Sint32 ellipseOverscan;
 
 	/*
 	* Sanity check radii 
@@ -1808,8 +1808,8 @@ bool aaellipseColor(SDL_Renderer * renderer, float x, float y, float rx, float r
 bool aaellipseRGBA(SDL_Renderer * renderer, float x, float y, float rx, float ry, Uint8 r, Uint8 g, Uint8 b, Uint8 a)
 {
 	bool result;
-	int i;
-	int a2, b2, ds, dt, dxt, t, s, d;
+	Sint32 i;
+	Sint32 a2, b2, ds, dt, dxt, t, s, d;
 	float xp, yp, xs, ys, dyt, od, xx, yy, xc2, yc2;
 	float cp;
 	double sab;
@@ -2048,13 +2048,13 @@ Note: Determines vertex array and uses polygon or filledPolygon drawing routines
 \returns Returns true on success, false on failure.
 */
 /* TODO: rewrite algorithm; pie is not always accurate */
-bool _pieRGBA(SDL_Renderer * renderer, float x, float y, float rad, int start, int end,  Uint8 r, Uint8 g, Uint8 b, Uint8 a, bool filled)
+bool _pieRGBA(SDL_Renderer * renderer, float x, float y, float rad, Sint32 start, Sint32 end,  Uint8 r, Uint8 g, Uint8 b, Uint8 a, bool filled)
 {
 	bool result;
 	double angle, start_angle, end_angle;
 	double deltaAngle;
 	double dr;
-	int numpoints, i;
+	Sint32 numpoints, i;
 	float *vx, *vy;
 
 	/*
@@ -2164,7 +2164,7 @@ bool _pieRGBA(SDL_Renderer * renderer, float x, float y, float rad, int start, i
 \returns Returns true on success, false on failure.
 */
 bool pieColor(SDL_Renderer * renderer, float x, float y, float rad,
-	int start, int end, Uint32 color)
+	Sint32 start, Sint32 end, Uint32 color)
 {
 	Uint8 *c = (Uint8 *)&color; 
 	return _pieRGBA(renderer, x, y, rad, start, end, c[0], c[1], c[2], c[3], 0);
@@ -2187,7 +2187,7 @@ bool pieColor(SDL_Renderer * renderer, float x, float y, float rad,
 \returns Returns true on success, false on failure.
 */
 bool pieRGBA(SDL_Renderer * renderer, float x, float y, float rad,
-	int start, int end, Uint8 r, Uint8 g, Uint8 b, Uint8 a)
+	Sint32 start, Sint32 end, Uint8 r, Uint8 g, Uint8 b, Uint8 a)
 {
 	return _pieRGBA(renderer, x, y, rad, start, end, r, g, b, a, 0);
 }
@@ -2205,7 +2205,7 @@ bool pieRGBA(SDL_Renderer * renderer, float x, float y, float rad,
 
 \returns Returns true on success, false on failure.
 */
-bool filledPieColor(SDL_Renderer * renderer, float x, float y, float rad, int start, int end, Uint32 color)
+bool filledPieColor(SDL_Renderer * renderer, float x, float y, float rad, Sint32 start, Sint32 end, Uint32 color)
 {
 	Uint8 *c = (Uint8 *)&color; 
 	return _pieRGBA(renderer, x, y, rad, start, end, c[0], c[1], c[2], c[3], 1);
@@ -2228,7 +2228,7 @@ bool filledPieColor(SDL_Renderer * renderer, float x, float y, float rad, int st
 \returns Returns true on success, false on failure.
 */
 bool filledPieRGBA(SDL_Renderer * renderer, float x, float y, float rad,
-	int start, int end, Uint8 r, Uint8 g, Uint8 b, Uint8 a)
+	Sint32 start, Sint32 end, Uint8 r, Uint8 g, Uint8 b, Uint8 a)
 {
 	return _pieRGBA(renderer, x, y, rad, start, end, r, g, b, a, 1);
 }
@@ -2446,7 +2446,7 @@ bool filledTrigonRGBA(SDL_Renderer * renderer, float x1, float y1, float x2, flo
 
 \returns Returns true on success, false on failure.
 */
-bool polygonColor(SDL_Renderer * renderer, const float * vx, const float * vy, int n, Uint32 color)
+bool polygonColor(SDL_Renderer * renderer, const float * vx, const float * vy, Sint32 n, Uint32 color)
 {
 	Uint8 *c = (Uint8 *)&color; 
 	return polygonRGBA(renderer, vx, vy, n, c[0], c[1], c[2], c[3]);
@@ -2462,13 +2462,13 @@ bool polygonColor(SDL_Renderer * renderer, const float * vx, const float * vy, i
 
 \returns Returns true on success, false on failure.
 */
-bool polygon(SDL_Renderer * renderer, const float * vx, const float * vy, int n)
+bool polygon(SDL_Renderer * renderer, const float * vx, const float * vy, Sint32 n)
 {
 	/*
 	* Draw 
 	*/
 	bool result = true;
-	int i, nn;
+	Sint32 i, nn;
 	SDL_FPoint* points;
 
 	/*
@@ -2528,7 +2528,7 @@ bool polygon(SDL_Renderer * renderer, const float * vx, const float * vy, int n)
 
 \returns Returns true on success, false on failure.
 */
-bool polygonRGBA(SDL_Renderer * renderer, const float * vx, const float * vy, int n, Uint8 r, Uint8 g, Uint8 b, Uint8 a)
+bool polygonRGBA(SDL_Renderer * renderer, const float * vx, const float * vy, Sint32 n, Uint8 r, Uint8 g, Uint8 b, Uint8 a)
 {
 	/*
 	* Draw 
@@ -2589,7 +2589,7 @@ bool polygonRGBA(SDL_Renderer * renderer, const float * vx, const float * vy, in
 
 \returns Returns true on success, false on failure.
 */
-bool aapolygonColor(SDL_Renderer * renderer, const float * vx, const float * vy, int n, Uint32 color)
+bool aapolygonColor(SDL_Renderer * renderer, const float * vx, const float * vy, Sint32 n, Uint32 color)
 {
 	Uint8 *c = (Uint8 *)&color; 
 	return aapolygonRGBA(renderer, vx, vy, n, c[0], c[1], c[2], c[3]);
@@ -2609,10 +2609,10 @@ bool aapolygonColor(SDL_Renderer * renderer, const float * vx, const float * vy,
 
 \returns Returns true on success, false on failure.
 */
-bool aapolygonRGBA(SDL_Renderer * renderer, const float * vx, const float * vy, int n, Uint8 r, Uint8 g, Uint8 b, Uint8 a)
+bool aapolygonRGBA(SDL_Renderer * renderer, const float * vx, const float * vy, Sint32 n, Uint8 r, Uint8 g, Uint8 b, Uint8 a)
 {
 	bool result;
-	int i;
+	Sint32 i;
 	const float *x1, *y1, *x2, *y2;
 
 	/*
@@ -2667,9 +2667,9 @@ bool aapolygonRGBA(SDL_Renderer * renderer, const float * vx, const float * vy, 
 
 \returns Returns 0 if a==b, a negative number if a<b or a positive number if a>b.
 */
-int _gfxPrimitivesCompareInt(const void *a, const void *b)
+Sint32 _gfxPrimitivesCompareInt(const void *a, const void *b)
 {
-	return (*(const int *) a) - (*(const int *) b);
+	return (*(const Sint32 *) a) - (*(const Sint32 *) b);
 }
 
 /*!
@@ -2677,7 +2677,7 @@ int _gfxPrimitivesCompareInt(const void *a, const void *b)
 
 Note: Used for non-multithreaded (default) operation of filledPolygonMT.
 */
-static int *gfxPrimitivesPolyIntsGlobal = NULL;
+static Sint32 *gfxPrimitivesPolyIntsGlobal = NULL;
 
 /*!
 \brief Flag indicating if global vertex array was already allocated.
@@ -2704,18 +2704,18 @@ Note: The last two parameters are optional; but are required for multithreaded o
 
 \returns Returns true on success, false on failure.
 */
-bool filledPolygonRGBAMT(SDL_Renderer * renderer, const float * vx, const float * vy, int n, Uint8 r, Uint8 g, Uint8 b, Uint8 a, int **polyInts, bool *polyAllocated)
+bool filledPolygonRGBAMT(SDL_Renderer * renderer, const float * vx, const float * vy, Sint32 n, Uint8 r, Uint8 g, Uint8 b, Uint8 a, Sint32 **polyInts, bool *polyAllocated)
 {
 	bool result;
-	int i;
-	int y, xa, xb;
-	int miny, maxy;
-	int x1, y1;
-	int x2, y2;
-	int ind1, ind2;
-	int ints;
-	int *gfxPrimitivesPolyInts = NULL;
-	int *gfxPrimitivesPolyIntsNew = NULL;
+	Sint32 i;
+	Sint32 y, xa, xb;
+	Sint32 miny, maxy;
+	Sint32 x1, y1;
+	Sint32 x2, y2;
+	Sint32 ind1, ind2;
+	Sint32 ints;
+	Sint32 *gfxPrimitivesPolyInts = NULL;
+	Sint32 *gfxPrimitivesPolyIntsNew = NULL;
 	bool gfxPrimitivesPolyAllocated = false;
 
 	/*
@@ -2752,11 +2752,11 @@ bool filledPolygonRGBAMT(SDL_Renderer * renderer, const float * vx, const float 
 	* Allocate temp array, only grow array 
 	*/
 	if (!gfxPrimitivesPolyAllocated) {
-		gfxPrimitivesPolyInts = (int *) malloc(sizeof(int) * n);
+		gfxPrimitivesPolyInts = (Sint32 *) malloc(sizeof(int) * n);
 		gfxPrimitivesPolyAllocated = n;
 	} else {
 		if (gfxPrimitivesPolyAllocated < n) {
-			gfxPrimitivesPolyIntsNew = (int *) realloc(gfxPrimitivesPolyInts, sizeof(int) * n);
+			gfxPrimitivesPolyIntsNew = (Sint32 *) realloc(gfxPrimitivesPolyInts, sizeof(int) * n);
 			if (!gfxPrimitivesPolyIntsNew) {
 				if (!gfxPrimitivesPolyInts) {
 					free(gfxPrimitivesPolyInts);
@@ -2871,7 +2871,7 @@ bool filledPolygonRGBAMT(SDL_Renderer * renderer, const float * vx, const float 
 
 \returns Returns true on success, false on failure.
 */
-bool filledPolygonColor(SDL_Renderer * renderer, const float * vx, const float * vy, int n, Uint32 color)
+bool filledPolygonColor(SDL_Renderer * renderer, const float * vx, const float * vy, Sint32 n, Uint32 color)
 {
 	Uint8 *c = (Uint8 *)&color; 
 	return filledPolygonRGBAMT(renderer, vx, vy, n, c[0], c[1], c[2], c[3], NULL, NULL);
@@ -2891,7 +2891,7 @@ bool filledPolygonColor(SDL_Renderer * renderer, const float * vx, const float *
 
 \returns Returns true on success, false on failure.
 */
-bool filledPolygonRGBA(SDL_Renderer * renderer, const float * vx, const float * vy, int n, Uint8 r, Uint8 g, Uint8 b, Uint8 a)
+bool filledPolygonRGBA(SDL_Renderer * renderer, const float * vx, const float * vy, Sint32 n, Uint8 r, Uint8 g, Uint8 b, Uint8 a)
 {
 	return filledPolygonRGBAMT(renderer, vx, vy, n, r, g, b, a, NULL, NULL);
 }
@@ -2913,15 +2913,15 @@ bool filledPolygonRGBA(SDL_Renderer * renderer, const float * vx, const float * 
 
 \returns Returns true on success, false on failure.
 */
-bool _HLineTextured(SDL_Renderer *renderer, float x1, float x2, float y, SDL_Texture *texture, int texture_w, int texture_h, int texture_dx, int texture_dy)
+bool _HLineTextured(SDL_Renderer *renderer, float x1, float x2, float y, SDL_Texture *texture, Sint32 texture_w, Sint32 texture_h, Sint32 texture_dx, Sint32 texture_dy)
 {
 	float w;
 	float xtmp;
 	bool result = true;
-	int texture_x_walker;    
-	int texture_y_start;    
+	Sint32 texture_x_walker;
+	Sint32 texture_y_start;
 	SDL_FRect source_rect,dst_rect;
-	int pixels_written,write_width;
+	Sint32 pixels_written,write_width;
 
 	/*
 	* Swap x1, x2 if required to ensure x1<=x2
@@ -3012,20 +3012,20 @@ to the left and want the texture to apear the same you need to increase the text
 
 \returns Returns true on success, false on failure.
 */
-bool texturedPolygonMT(SDL_Renderer *renderer, const float * vx, const float * vy, int n,
-	SDL_Surface * texture, int texture_dx, int texture_dy, int **polyInts, bool *polyAllocated)
+bool texturedPolygonMT(SDL_Renderer *renderer, const float * vx, const float * vy, Sint32 n,
+	SDL_Surface * texture, Sint32 texture_dx, Sint32 texture_dy, Sint32 **polyInts, bool *polyAllocated)
 {
 	bool result;
-	int i;
-	int y, xa, xb;
-	int minx,maxx,miny, maxy;
-	int x1, y1;
-	int x2, y2;
-	int ind1, ind2;
-	int ints;
-	int *gfxPrimitivesPolyInts = NULL;
-	int *gfxPrimitivesPolyIntsTemp = NULL;
-	int gfxPrimitivesPolyAllocated = 0;
+	Sint32 i;
+	Sint32 y, xa, xb;
+	Sint32 minx,maxx,miny, maxy;
+	Sint32 x1, y1;
+	Sint32 x2, y2;
+	Sint32 ind1, ind2;
+	Sint32 ints;
+	Sint32 *gfxPrimitivesPolyInts = NULL;
+	Sint32 *gfxPrimitivesPolyIntsTemp = NULL;
+	Sint32 gfxPrimitivesPolyAllocated = 0;
 	SDL_Texture *textureAsTexture = NULL;
 
 	/*
@@ -3052,11 +3052,11 @@ bool texturedPolygonMT(SDL_Renderer *renderer, const float * vx, const float * v
 	* Allocate temp array, only grow array 
 	*/
 	if (!gfxPrimitivesPolyAllocated) {
-		gfxPrimitivesPolyInts = (int *) malloc(sizeof(int) * n);
+		gfxPrimitivesPolyInts = (Sint32 *) malloc(sizeof(int) * n);
 		gfxPrimitivesPolyAllocated = n;
 	} else {
 		if (gfxPrimitivesPolyAllocated < n) {
-			gfxPrimitivesPolyIntsTemp = (int *) realloc(gfxPrimitivesPolyInts, sizeof(int) * n);
+			gfxPrimitivesPolyIntsTemp = (Sint32 *) realloc(gfxPrimitivesPolyInts, sizeof(int) * n);
 			if (gfxPrimitivesPolyIntsTemp == NULL) {
 				/* Realloc failed - keeps original memory block, but fails this operation */
 				return(false);
@@ -3183,7 +3183,7 @@ to the left and want the texture to apear the same you need to increase the text
 
 \returns Returns true on success, false on failure.
 */
-bool texturedPolygon(SDL_Renderer *renderer, const float * vx, const float * vy, int n, SDL_Surface *texture, int texture_dx, int texture_dy)
+bool texturedPolygon(SDL_Renderer *renderer, const float * vx, const float * vy, Sint32 n, SDL_Surface *texture, Sint32 texture_dx, Sint32 texture_dy)
 {
 	/*
 	* Draw
@@ -3206,37 +3206,37 @@ static const unsigned char *currentFontdata = gfxPrimitivesFontdata;
 /*!
 \brief Width of the current font. Default is 8. 
 */
-static unsigned int charWidth = 8;
+static Uint32 charWidth = 8;
 
 /*!
 \brief Height of the current font. Default is 8. 
 */
-static unsigned int charHeight = 8;
+static Uint32 charHeight = 8;
 
 /*!
 \brief Width for rendering. Autocalculated.
 */
-static unsigned int charWidthLocal = 8;
+static Uint32 charWidthLocal = 8;
 
 /*!
 \brief Height for rendering. Autocalculated.
 */
-static unsigned int charHeightLocal = 8;
+static Uint32 charHeightLocal = 8;
 
 /*!
 \brief Pitch of the current font in bytes. Default is 1. 
 */
-static unsigned int charPitch = 1;
+static Uint32 charPitch = 1;
 
 /*!
 \brief Characters 90deg clockwise rotations. Default is 0. Max is 3. 
 */
-static unsigned int charRotation = 0;
+static Uint32 charRotation = 0;
 
 /*!
 \brief Character data size in bytes of the current font. Default is 8. 
 */
-static unsigned int charSize = 8;
+static Uint32 charSize = 8;
 
 /*!
 \brief Sets or resets the current global font data.
@@ -3251,9 +3251,9 @@ The font data array is organized in follows:
 \param cw Width of character in bytes. Ignored if fontdata==NULL.
 \param ch Height of character in bytes. Ignored if fontdata==NULL.
 */
-void gfxPrimitivesSetFont(const void *fontdata, unsigned int cw, unsigned int ch)
+void gfxPrimitivesSetFont(const void *fontdata, Uint32 cw, Uint32 ch)
 {
-	int i;
+	Sint32 i;
 
 	if ((fontdata) && (cw) && (ch)) {
 		currentFontdata = (unsigned char *)fontdata;
@@ -3297,9 +3297,9 @@ Changing the rotation, will reset the character cache.
 
 \param rotation Number of 90deg clockwise steps to rotate
 */
-void gfxPrimitivesSetFontRotation(unsigned int rotation)
+void gfxPrimitivesSetFontRotation(Uint32 rotation)
 {
-	int i;
+	Sint32 i;
 
 	rotation = rotation & 3;
 	if (charRotation != rotation)
@@ -3348,15 +3348,15 @@ bool characterRGBA(SDL_Renderer *renderer, float x, float y, char c, Uint8 r, Ui
 	SDL_FRect srect;
 	SDL_FRect drect;
 	bool result;
-	unsigned int ix, iy;
+	Uint32 ix, iy;
 	const unsigned char *charpos;
 	Uint8 *curpos;
 	Uint8 patt, mask;
 	Uint8 *linepos;
-	unsigned int pitch;
+	Uint32 pitch;
 	SDL_Surface *character;
 	SDL_Surface *rotatedCharacter;
-	unsigned int ci;
+	Uint32 ci;
 
 	/*
 	* Setup source rectangle
@@ -3408,9 +3408,9 @@ bool characterRGBA(SDL_Renderer *renderer, float x, float y, char c, Uint8 r, Ui
 					mask = 0x80;
 				}
 				if (patt & mask) {
-					*(unsigned int *)curpos = 0xffffffff;
+					*(Uint32 *)curpos = 0xffffffff;
 				} else {
-					*(unsigned int *)curpos = 0;
+					*(Uint32 *)curpos = 0;
 				}
 				curpos += 4;
 			}
@@ -3546,10 +3546,10 @@ bool stringRGBA(SDL_Renderer * renderer, float x, float y, const char *s, Uint8 
 
 \returns Interpolated value at position t, value[0] when t<0, value[n-1] when t>n.
 */
-double _evaluateBezier (double *data, int ndata, double t) 
+double _evaluateBezier (double *data, Sint32 ndata, double t)
 {
 	double mu, result;
-	int n,k,kn,nn,nkn;
+	Sint32 n,k,kn,nn,nkn;
 	double blend,muk,munk;
 
 	/* Sanity check bounds */
@@ -3605,7 +3605,7 @@ double _evaluateBezier (double *data, int ndata, double t)
 
 \returns Returns true on success, false on failure.
 */
-bool bezierColor(SDL_Renderer * renderer, const float * vx, const float * vy, int n, int s, Uint32 color)
+bool bezierColor(SDL_Renderer * renderer, const float * vx, const float * vy, Sint32 n, Sint32 s, Uint32 color)
 {
 	Uint8 *c = (Uint8 *)&color; 
 	return bezierRGBA(renderer, vx, vy, n, s, c[0], c[1], c[2], c[3]);
@@ -3626,10 +3626,10 @@ bool bezierColor(SDL_Renderer * renderer, const float * vx, const float * vy, in
 
 \returns Returns true on success, false on failure.
 */
-bool bezierRGBA(SDL_Renderer * renderer, const float * vx, const float * vy, int n, int s, Uint8 r, Uint8 g, Uint8 b, Uint8 a)
+bool bezierRGBA(SDL_Renderer * renderer, const float * vx, const float * vy, Sint32 n, Sint32 s, Uint8 r, Uint8 g, Uint8 b, Uint8 a)
 {
 	bool result;
-	int i;
+	Sint32 i;
 	double *x, *y, t, stepsize;
 	float x1, y1, x2, y2;
 
@@ -3730,7 +3730,7 @@ bool thickLineColor(SDL_Renderer *renderer, float x1, float y1, float x2, float 
 */
 bool thickLineRGBA(SDL_Renderer *renderer, float x1, float y1, float x2, float y2, Uint8 width, Uint8 r, Uint8 g, Uint8 b, Uint8 a)
 {
-	int wh;
+	Sint32 wh;
 	double dx, dy, dx1, dy1, dx2, dy2;
 	double l, wl2, nx, ny, ang, adj;
 	float px[4], py[4];

--- a/SDL3_gfxPrimitives.h
+++ b/SDL3_gfxPrimitives.h
@@ -130,8 +130,8 @@ extern "C" {
 
 	/* Arc */
 
-	SDL3_GFXPRIMITIVES_SCOPE bool arcColor(SDL_Renderer * renderer, float x, float y, float rad, int start, int end, Uint32 color);
-	SDL3_GFXPRIMITIVES_SCOPE bool arcRGBA(SDL_Renderer * renderer, float x, float y, float rad, int start, int end,
+	SDL3_GFXPRIMITIVES_SCOPE bool arcColor(SDL_Renderer * renderer, float x, float y, float rad, Sint32 start, Sint32 end, Uint32 color);
+	SDL3_GFXPRIMITIVES_SCOPE bool arcRGBA(SDL_Renderer * renderer, float x, float y, float rad, Sint32 start, Sint32 end,
 		Uint8 r, Uint8 g, Uint8 b, Uint8 a);
 
 	/* AA Circle */
@@ -167,16 +167,16 @@ extern "C" {
 	/* Pie */
 
 	SDL3_GFXPRIMITIVES_SCOPE bool pieColor(SDL_Renderer * renderer, float x, float y, float rad,
-		int start, int end, Uint32 color);
+		Sint32 start, Sint32 end, Uint32 color);
 	SDL3_GFXPRIMITIVES_SCOPE bool pieRGBA(SDL_Renderer * renderer, float x, float y, float rad,
-		int start, int end, Uint8 r, Uint8 g, Uint8 b, Uint8 a);
+		Sint32 start, Sint32 end, Uint8 r, Uint8 g, Uint8 b, Uint8 a);
 
 	/* Filled Pie */
 
 	SDL3_GFXPRIMITIVES_SCOPE bool filledPieColor(SDL_Renderer * renderer, float x, float y, float rad,
-		int start, int end, Uint32 color);
+		Sint32 start, Sint32 end, Uint32 color);
 	SDL3_GFXPRIMITIVES_SCOPE bool filledPieRGBA(SDL_Renderer * renderer, float x, float y, float rad,
-		int start, int end, Uint8 r, Uint8 g, Uint8 b, Uint8 a);
+		Sint32 start, Sint32 end, Uint8 r, Uint8 g, Uint8 b, Uint8 a);
 
 	/* Trigon */
 
@@ -198,36 +198,36 @@ extern "C" {
 
 	/* Polygon */
 
-	SDL3_GFXPRIMITIVES_SCOPE bool polygonColor(SDL_Renderer * renderer, const float * vx, const float * vy, int n, Uint32 color);
+	SDL3_GFXPRIMITIVES_SCOPE bool polygonColor(SDL_Renderer * renderer, const float * vx, const float * vy, Sint32 n, Uint32 color);
 	SDL3_GFXPRIMITIVES_SCOPE bool polygonRGBA(SDL_Renderer * renderer, const float * vx, const float * vy,
-		int n, Uint8 r, Uint8 g, Uint8 b, Uint8 a);
+		Sint32 n, Uint8 r, Uint8 g, Uint8 b, Uint8 a);
 
 	/* AA-Polygon */
 
-	SDL3_GFXPRIMITIVES_SCOPE bool aapolygonColor(SDL_Renderer * renderer, const float * vx, const float * vy, int n, Uint32 color);
+	SDL3_GFXPRIMITIVES_SCOPE bool aapolygonColor(SDL_Renderer * renderer, const float * vx, const float * vy, Sint32 n, Uint32 color);
 	SDL3_GFXPRIMITIVES_SCOPE bool aapolygonRGBA(SDL_Renderer * renderer, const float * vx, const float * vy,
-		int n, Uint8 r, Uint8 g, Uint8 b, Uint8 a);
+		Sint32 n, Uint8 r, Uint8 g, Uint8 b, Uint8 a);
 
 	/* Filled Polygon */
 
-	SDL3_GFXPRIMITIVES_SCOPE bool filledPolygonColor(SDL_Renderer * renderer, const float * vx, const float * vy, int n, Uint32 color);
+	SDL3_GFXPRIMITIVES_SCOPE bool filledPolygonColor(SDL_Renderer * renderer, const float * vx, const float * vy, Sint32 n, Uint32 color);
 	SDL3_GFXPRIMITIVES_SCOPE bool filledPolygonRGBA(SDL_Renderer * renderer, const float * vx,
-		const float * vy, int n, Uint8 r, Uint8 g, Uint8 b, Uint8 a);
+		const float * vy, Sint32 n, Uint8 r, Uint8 g, Uint8 b, Uint8 a);
 
 	/* Textured Polygon */
 
-	SDL3_GFXPRIMITIVES_SCOPE bool texturedPolygon(SDL_Renderer * renderer, const float * vx, const float * vy, int n, SDL_Surface * texture,int texture_dx,int texture_dy);
+	SDL3_GFXPRIMITIVES_SCOPE bool texturedPolygon(SDL_Renderer * renderer, const float * vx, const float * vy, Sint32 n, SDL_Surface * texture,Sint32 texture_dx,Sint32 texture_dy);
 
 	/* Bezier */
 
-	SDL3_GFXPRIMITIVES_SCOPE bool bezierColor(SDL_Renderer * renderer, const float * vx, const float * vy, int n, int s, Uint32 color);
+	SDL3_GFXPRIMITIVES_SCOPE bool bezierColor(SDL_Renderer * renderer, const float * vx, const float * vy, Sint32 n, Sint32 s, Uint32 color);
 	SDL3_GFXPRIMITIVES_SCOPE bool bezierRGBA(SDL_Renderer * renderer, const float * vx, const float * vy,
-		int n, int s, Uint8 r, Uint8 g, Uint8 b, Uint8 a);
+		Sint32 n, Sint32 s, Uint8 r, Uint8 g, Uint8 b, Uint8 a);
 
 	/* Characters/Strings */
 
-	SDL3_GFXPRIMITIVES_SCOPE void gfxPrimitivesSetFont(const void *fontdata, unsigned int cw, unsigned int ch);
-	SDL3_GFXPRIMITIVES_SCOPE void gfxPrimitivesSetFontRotation(unsigned int rotation);
+	SDL3_GFXPRIMITIVES_SCOPE void gfxPrimitivesSetFont(const void *fontdata, Uint32 cw, Uint32 ch);
+	SDL3_GFXPRIMITIVES_SCOPE void gfxPrimitivesSetFontRotation(Uint32 rotation);
 	SDL3_GFXPRIMITIVES_SCOPE bool characterColor(SDL_Renderer * renderer, float x, float y, char c, Uint32 color);
 	SDL3_GFXPRIMITIVES_SCOPE bool characterRGBA(SDL_Renderer * renderer, float x, float y, char c, Uint8 r, Uint8 g, Uint8 b, Uint8 a);
 	SDL3_GFXPRIMITIVES_SCOPE bool stringColor(SDL_Renderer * renderer, float x, float y, const char *s, Uint32 color);

--- a/SDL3_gfxPrimitives.h
+++ b/SDL3_gfxPrimitives.h
@@ -68,170 +68,170 @@ extern "C" {
 
 	/* Pixel */
 
-	SDL3_GFXPRIMITIVES_SCOPE bool pixelColor(SDL_Renderer * renderer, Sint16 x, Sint16 y, Uint32 color);
-	SDL3_GFXPRIMITIVES_SCOPE bool pixelRGBA(SDL_Renderer * renderer, Sint16 x, Sint16 y, Uint8 r, Uint8 g, Uint8 b, Uint8 a);
+	SDL3_GFXPRIMITIVES_SCOPE bool pixelColor(SDL_Renderer * renderer, float x, float y, Uint32 color);
+	SDL3_GFXPRIMITIVES_SCOPE bool pixelRGBA(SDL_Renderer * renderer, float x, float y, Uint8 r, Uint8 g, Uint8 b, Uint8 a);
 
 	/* Horizontal line */
 
-	SDL3_GFXPRIMITIVES_SCOPE bool hlineColor(SDL_Renderer * renderer, Sint16 x1, Sint16 x2, Sint16 y, Uint32 color);
-	SDL3_GFXPRIMITIVES_SCOPE bool hlineRGBA(SDL_Renderer * renderer, Sint16 x1, Sint16 x2, Sint16 y, Uint8 r, Uint8 g, Uint8 b, Uint8 a);
+	SDL3_GFXPRIMITIVES_SCOPE bool hlineColor(SDL_Renderer * renderer, float x1, float x2, float y, Uint32 color);
+	SDL3_GFXPRIMITIVES_SCOPE bool hlineRGBA(SDL_Renderer * renderer, float x1, float x2, float y, Uint8 r, Uint8 g, Uint8 b, Uint8 a);
 
 	/* Vertical line */
 
-	SDL3_GFXPRIMITIVES_SCOPE bool vlineColor(SDL_Renderer * renderer, Sint16 x, Sint16 y1, Sint16 y2, Uint32 color);
-	SDL3_GFXPRIMITIVES_SCOPE bool vlineRGBA(SDL_Renderer * renderer, Sint16 x, Sint16 y1, Sint16 y2, Uint8 r, Uint8 g, Uint8 b, Uint8 a);
+	SDL3_GFXPRIMITIVES_SCOPE bool vlineColor(SDL_Renderer * renderer, float x, float y1, float y2, Uint32 color);
+	SDL3_GFXPRIMITIVES_SCOPE bool vlineRGBA(SDL_Renderer * renderer, float x, float y1, float y2, Uint8 r, Uint8 g, Uint8 b, Uint8 a);
 
 	/* Rectangle */
 
-	SDL3_GFXPRIMITIVES_SCOPE bool rectangleColor(SDL_Renderer * renderer, Sint16 x1, Sint16 y1, Sint16 x2, Sint16 y2, Uint32 color);
-	SDL3_GFXPRIMITIVES_SCOPE bool rectangleRGBA(SDL_Renderer * renderer, Sint16 x1, Sint16 y1,
-		Sint16 x2, Sint16 y2, Uint8 r, Uint8 g, Uint8 b, Uint8 a);
+	SDL3_GFXPRIMITIVES_SCOPE bool rectangleColor(SDL_Renderer * renderer, float x1, float y1, float x2, float y2, Uint32 color);
+	SDL3_GFXPRIMITIVES_SCOPE bool rectangleRGBA(SDL_Renderer * renderer, float x1, float y1,
+		float x2, float y2, Uint8 r, Uint8 g, Uint8 b, Uint8 a);
 
 	/* Rounded-Corner Rectangle */
 
-	SDL3_GFXPRIMITIVES_SCOPE bool roundedRectangleColor(SDL_Renderer * renderer, Sint16 x1, Sint16 y1, Sint16 x2, Sint16 y2, Sint16 rad, Uint32 color);
-	SDL3_GFXPRIMITIVES_SCOPE bool roundedRectangleRGBA(SDL_Renderer * renderer, Sint16 x1, Sint16 y1,
-		Sint16 x2, Sint16 y2, Sint16 rad, Uint8 r, Uint8 g, Uint8 b, Uint8 a);
+	SDL3_GFXPRIMITIVES_SCOPE bool roundedRectangleColor(SDL_Renderer * renderer, float x1, float y1, float x2, float y2, float rad, Uint32 color);
+	SDL3_GFXPRIMITIVES_SCOPE bool roundedRectangleRGBA(SDL_Renderer * renderer, float x1, float y1,
+		float x2, float y2, float rad, Uint8 r, Uint8 g, Uint8 b, Uint8 a);
 
 	/* Filled rectangle (Box) */
 
-	SDL3_GFXPRIMITIVES_SCOPE bool boxColor(SDL_Renderer * renderer, Sint16 x1, Sint16 y1, Sint16 x2, Sint16 y2, Uint32 color);
-	SDL3_GFXPRIMITIVES_SCOPE bool boxRGBA(SDL_Renderer * renderer, Sint16 x1, Sint16 y1, Sint16 x2,
-		Sint16 y2, Uint8 r, Uint8 g, Uint8 b, Uint8 a);
+	SDL3_GFXPRIMITIVES_SCOPE bool boxColor(SDL_Renderer * renderer, float x1, float y1, float x2, float y2, Uint32 color);
+	SDL3_GFXPRIMITIVES_SCOPE bool boxRGBA(SDL_Renderer * renderer, float x1, float y1, float x2,
+		float y2, Uint8 r, Uint8 g, Uint8 b, Uint8 a);
 
 	/* Rounded-Corner Filled rectangle (Box) */
 
-	SDL3_GFXPRIMITIVES_SCOPE bool roundedBoxColor(SDL_Renderer * renderer, Sint16 x1, Sint16 y1, Sint16 x2, Sint16 y2, Sint16 rad, Uint32 color);
-	SDL3_GFXPRIMITIVES_SCOPE bool roundedBoxRGBA(SDL_Renderer * renderer, Sint16 x1, Sint16 y1, Sint16 x2,
-		Sint16 y2, Sint16 rad, Uint8 r, Uint8 g, Uint8 b, Uint8 a);
+	SDL3_GFXPRIMITIVES_SCOPE bool roundedBoxColor(SDL_Renderer * renderer, float x1, float y1, float x2, float y2, float rad, Uint32 color);
+	SDL3_GFXPRIMITIVES_SCOPE bool roundedBoxRGBA(SDL_Renderer * renderer, float x1, float y1, float x2,
+		float y2, float rad, Uint8 r, Uint8 g, Uint8 b, Uint8 a);
 
 	/* Line */
 
-	SDL3_GFXPRIMITIVES_SCOPE bool lineColor(SDL_Renderer * renderer, Sint16 x1, Sint16 y1, Sint16 x2, Sint16 y2, Uint32 color);
-	SDL3_GFXPRIMITIVES_SCOPE bool lineRGBA(SDL_Renderer * renderer, Sint16 x1, Sint16 y1,
-		Sint16 x2, Sint16 y2, Uint8 r, Uint8 g, Uint8 b, Uint8 a);
+	SDL3_GFXPRIMITIVES_SCOPE bool lineColor(SDL_Renderer * renderer, float x1, float y1, float x2, float y2, Uint32 color);
+	SDL3_GFXPRIMITIVES_SCOPE bool lineRGBA(SDL_Renderer * renderer, float x1, float y1,
+		float x2, float y2, Uint8 r, Uint8 g, Uint8 b, Uint8 a);
 
 	/* AA Line */
 
-	SDL3_GFXPRIMITIVES_SCOPE bool aalineColor(SDL_Renderer * renderer, Sint16 x1, Sint16 y1, Sint16 x2, Sint16 y2, Uint32 color);
-	SDL3_GFXPRIMITIVES_SCOPE bool aalineRGBA(SDL_Renderer * renderer, Sint16 x1, Sint16 y1,
-		Sint16 x2, Sint16 y2, Uint8 r, Uint8 g, Uint8 b, Uint8 a);
+	SDL3_GFXPRIMITIVES_SCOPE bool aalineColor(SDL_Renderer * renderer, float x1, float y1, float x2, float y2, Uint32 color);
+	SDL3_GFXPRIMITIVES_SCOPE bool aalineRGBA(SDL_Renderer * renderer, float x1, float y1,
+		float x2, float y2, Uint8 r, Uint8 g, Uint8 b, Uint8 a);
 
 	/* Thick Line */
-	SDL3_GFXPRIMITIVES_SCOPE bool thickLineColor(SDL_Renderer * renderer, Sint16 x1, Sint16 y1, Sint16 x2, Sint16 y2,
+	SDL3_GFXPRIMITIVES_SCOPE bool thickLineColor(SDL_Renderer * renderer, float x1, float y1, float x2, float y2,
 		Uint8 width, Uint32 color);
-	SDL3_GFXPRIMITIVES_SCOPE bool thickLineRGBA(SDL_Renderer * renderer, Sint16 x1, Sint16 y1, Sint16 x2, Sint16 y2,
+	SDL3_GFXPRIMITIVES_SCOPE bool thickLineRGBA(SDL_Renderer * renderer, float x1, float y1, float x2, float y2,
 		Uint8 width, Uint8 r, Uint8 g, Uint8 b, Uint8 a);
 
 	/* Circle */
 
-	SDL3_GFXPRIMITIVES_SCOPE bool circleColor(SDL_Renderer * renderer, Sint16 x, Sint16 y, Sint16 rad, Uint32 color);
-	SDL3_GFXPRIMITIVES_SCOPE bool circleRGBA(SDL_Renderer * renderer, Sint16 x, Sint16 y, Sint16 rad, Uint8 r, Uint8 g, Uint8 b, Uint8 a);
+	SDL3_GFXPRIMITIVES_SCOPE bool circleColor(SDL_Renderer * renderer, float x, float y, float rad, Uint32 color);
+	SDL3_GFXPRIMITIVES_SCOPE bool circleRGBA(SDL_Renderer * renderer, float x, float y, float rad, Uint8 r, Uint8 g, Uint8 b, Uint8 a);
 
 	/* Arc */
 
-	SDL3_GFXPRIMITIVES_SCOPE bool arcColor(SDL_Renderer * renderer, Sint16 x, Sint16 y, Sint16 rad, Sint16 start, Sint16 end, Uint32 color);
-	SDL3_GFXPRIMITIVES_SCOPE bool arcRGBA(SDL_Renderer * renderer, Sint16 x, Sint16 y, Sint16 rad, Sint16 start, Sint16 end,
+	SDL3_GFXPRIMITIVES_SCOPE bool arcColor(SDL_Renderer * renderer, float x, float y, float rad, int start, int end, Uint32 color);
+	SDL3_GFXPRIMITIVES_SCOPE bool arcRGBA(SDL_Renderer * renderer, float x, float y, float rad, int start, int end,
 		Uint8 r, Uint8 g, Uint8 b, Uint8 a);
 
 	/* AA Circle */
 
-	SDL3_GFXPRIMITIVES_SCOPE bool aacircleColor(SDL_Renderer * renderer, Sint16 x, Sint16 y, Sint16 rad, Uint32 color);
-	SDL3_GFXPRIMITIVES_SCOPE bool aacircleRGBA(SDL_Renderer * renderer, Sint16 x, Sint16 y,
-		Sint16 rad, Uint8 r, Uint8 g, Uint8 b, Uint8 a);
+	SDL3_GFXPRIMITIVES_SCOPE bool aacircleColor(SDL_Renderer * renderer, float x, float y, float rad, Uint32 color);
+	SDL3_GFXPRIMITIVES_SCOPE bool aacircleRGBA(SDL_Renderer * renderer, float x, float y,
+		float rad, Uint8 r, Uint8 g, Uint8 b, Uint8 a);
 
 	/* Filled Circle */
 
-	SDL3_GFXPRIMITIVES_SCOPE bool filledCircleColor(SDL_Renderer * renderer, Sint16 x, Sint16 y, Sint16 r, Uint32 color);
-	SDL3_GFXPRIMITIVES_SCOPE bool filledCircleRGBA(SDL_Renderer * renderer, Sint16 x, Sint16 y,
-		Sint16 rad, Uint8 r, Uint8 g, Uint8 b, Uint8 a);
+	SDL3_GFXPRIMITIVES_SCOPE bool filledCircleColor(SDL_Renderer * renderer, float x, float y, float r, Uint32 color);
+	SDL3_GFXPRIMITIVES_SCOPE bool filledCircleRGBA(SDL_Renderer * renderer, float x, float y,
+		float rad, Uint8 r, Uint8 g, Uint8 b, Uint8 a);
 
 	/* Ellipse */
 
-	SDL3_GFXPRIMITIVES_SCOPE bool ellipseColor(SDL_Renderer * renderer, Sint16 x, Sint16 y, Sint16 rx, Sint16 ry, Uint32 color);
-	SDL3_GFXPRIMITIVES_SCOPE bool ellipseRGBA(SDL_Renderer * renderer, Sint16 x, Sint16 y,
-		Sint16 rx, Sint16 ry, Uint8 r, Uint8 g, Uint8 b, Uint8 a);
+	SDL3_GFXPRIMITIVES_SCOPE bool ellipseColor(SDL_Renderer * renderer, float x, float y, float rx, float ry, Uint32 color);
+	SDL3_GFXPRIMITIVES_SCOPE bool ellipseRGBA(SDL_Renderer * renderer, float x, float y,
+		float rx, float ry, Uint8 r, Uint8 g, Uint8 b, Uint8 a);
 
 	/* AA Ellipse */
 
-	SDL3_GFXPRIMITIVES_SCOPE bool aaellipseColor(SDL_Renderer * renderer, Sint16 x, Sint16 y, Sint16 rx, Sint16 ry, Uint32 color);
-	SDL3_GFXPRIMITIVES_SCOPE bool aaellipseRGBA(SDL_Renderer * renderer, Sint16 x, Sint16 y,
-		Sint16 rx, Sint16 ry, Uint8 r, Uint8 g, Uint8 b, Uint8 a);
+	SDL3_GFXPRIMITIVES_SCOPE bool aaellipseColor(SDL_Renderer * renderer, float x, float y, float rx, float ry, Uint32 color);
+	SDL3_GFXPRIMITIVES_SCOPE bool aaellipseRGBA(SDL_Renderer * renderer, float x, float y,
+		float rx, float ry, Uint8 r, Uint8 g, Uint8 b, Uint8 a);
 
 	/* Filled Ellipse */
 
-	SDL3_GFXPRIMITIVES_SCOPE bool filledEllipseColor(SDL_Renderer * renderer, Sint16 x, Sint16 y, Sint16 rx, Sint16 ry, Uint32 color);
-	SDL3_GFXPRIMITIVES_SCOPE bool filledEllipseRGBA(SDL_Renderer * renderer, Sint16 x, Sint16 y,
-		Sint16 rx, Sint16 ry, Uint8 r, Uint8 g, Uint8 b, Uint8 a);
+	SDL3_GFXPRIMITIVES_SCOPE bool filledEllipseColor(SDL_Renderer * renderer, float x, float y, float rx, float ry, Uint32 color);
+	SDL3_GFXPRIMITIVES_SCOPE bool filledEllipseRGBA(SDL_Renderer * renderer, float x, float y,
+		float rx, float ry, Uint8 r, Uint8 g, Uint8 b, Uint8 a);
 
 	/* Pie */
 
-	SDL3_GFXPRIMITIVES_SCOPE bool pieColor(SDL_Renderer * renderer, Sint16 x, Sint16 y, Sint16 rad,
-		Sint16 start, Sint16 end, Uint32 color);
-	SDL3_GFXPRIMITIVES_SCOPE bool pieRGBA(SDL_Renderer * renderer, Sint16 x, Sint16 y, Sint16 rad,
-		Sint16 start, Sint16 end, Uint8 r, Uint8 g, Uint8 b, Uint8 a);
+	SDL3_GFXPRIMITIVES_SCOPE bool pieColor(SDL_Renderer * renderer, float x, float y, float rad,
+		int start, int end, Uint32 color);
+	SDL3_GFXPRIMITIVES_SCOPE bool pieRGBA(SDL_Renderer * renderer, float x, float y, float rad,
+		int start, int end, Uint8 r, Uint8 g, Uint8 b, Uint8 a);
 
 	/* Filled Pie */
 
-	SDL3_GFXPRIMITIVES_SCOPE bool filledPieColor(SDL_Renderer * renderer, Sint16 x, Sint16 y, Sint16 rad,
-		Sint16 start, Sint16 end, Uint32 color);
-	SDL3_GFXPRIMITIVES_SCOPE bool filledPieRGBA(SDL_Renderer * renderer, Sint16 x, Sint16 y, Sint16 rad,
-		Sint16 start, Sint16 end, Uint8 r, Uint8 g, Uint8 b, Uint8 a);
+	SDL3_GFXPRIMITIVES_SCOPE bool filledPieColor(SDL_Renderer * renderer, float x, float y, float rad,
+		int start, int end, Uint32 color);
+	SDL3_GFXPRIMITIVES_SCOPE bool filledPieRGBA(SDL_Renderer * renderer, float x, float y, float rad,
+		int start, int end, Uint8 r, Uint8 g, Uint8 b, Uint8 a);
 
 	/* Trigon */
 
-	SDL3_GFXPRIMITIVES_SCOPE bool trigonColor(SDL_Renderer * renderer, Sint16 x1, Sint16 y1, Sint16 x2, Sint16 y2, Sint16 x3, Sint16 y3, Uint32 color);
-	SDL3_GFXPRIMITIVES_SCOPE bool trigonRGBA(SDL_Renderer * renderer, Sint16 x1, Sint16 y1, Sint16 x2, Sint16 y2, Sint16 x3, Sint16 y3,
+	SDL3_GFXPRIMITIVES_SCOPE bool trigonColor(SDL_Renderer * renderer, float x1, float y1, float x2, float y2, float x3, float y3, Uint32 color);
+	SDL3_GFXPRIMITIVES_SCOPE bool trigonRGBA(SDL_Renderer * renderer, float x1, float y1, float x2, float y2, float x3, float y3,
 		Uint8 r, Uint8 g, Uint8 b, Uint8 a);
 
 	/* AA-Trigon */
 
-	SDL3_GFXPRIMITIVES_SCOPE bool aatrigonColor(SDL_Renderer * renderer, Sint16 x1, Sint16 y1, Sint16 x2, Sint16 y2, Sint16 x3, Sint16 y3, Uint32 color);
-	SDL3_GFXPRIMITIVES_SCOPE bool aatrigonRGBA(SDL_Renderer * renderer,  Sint16 x1, Sint16 y1, Sint16 x2, Sint16 y2, Sint16 x3, Sint16 y3,
+	SDL3_GFXPRIMITIVES_SCOPE bool aatrigonColor(SDL_Renderer * renderer, float x1, float y1, float x2, float y2, float x3, float y3, Uint32 color);
+	SDL3_GFXPRIMITIVES_SCOPE bool aatrigonRGBA(SDL_Renderer * renderer,  float x1, float y1, float x2, float y2, float x3, float y3,
 		Uint8 r, Uint8 g, Uint8 b, Uint8 a);
 
 	/* Filled Trigon */
 
-	SDL3_GFXPRIMITIVES_SCOPE bool filledTrigonColor(SDL_Renderer * renderer, Sint16 x1, Sint16 y1, Sint16 x2, Sint16 y2, Sint16 x3, Sint16 y3, Uint32 color);
-	SDL3_GFXPRIMITIVES_SCOPE bool filledTrigonRGBA(SDL_Renderer * renderer, Sint16 x1, Sint16 y1, Sint16 x2, Sint16 y2, Sint16 x3, Sint16 y3,
+	SDL3_GFXPRIMITIVES_SCOPE bool filledTrigonColor(SDL_Renderer * renderer, float x1, float y1, float x2, float y2, float x3, float y3, Uint32 color);
+	SDL3_GFXPRIMITIVES_SCOPE bool filledTrigonRGBA(SDL_Renderer * renderer, float x1, float y1, float x2, float y2, float x3, float y3,
 		Uint8 r, Uint8 g, Uint8 b, Uint8 a);
 
 	/* Polygon */
 
-	SDL3_GFXPRIMITIVES_SCOPE bool polygonColor(SDL_Renderer * renderer, const Sint16 * vx, const Sint16 * vy, int n, Uint32 color);
-	SDL3_GFXPRIMITIVES_SCOPE bool polygonRGBA(SDL_Renderer * renderer, const Sint16 * vx, const Sint16 * vy,
+	SDL3_GFXPRIMITIVES_SCOPE bool polygonColor(SDL_Renderer * renderer, const float * vx, const float * vy, int n, Uint32 color);
+	SDL3_GFXPRIMITIVES_SCOPE bool polygonRGBA(SDL_Renderer * renderer, const float * vx, const float * vy,
 		int n, Uint8 r, Uint8 g, Uint8 b, Uint8 a);
 
 	/* AA-Polygon */
 
-	SDL3_GFXPRIMITIVES_SCOPE bool aapolygonColor(SDL_Renderer * renderer, const Sint16 * vx, const Sint16 * vy, int n, Uint32 color);
-	SDL3_GFXPRIMITIVES_SCOPE bool aapolygonRGBA(SDL_Renderer * renderer, const Sint16 * vx, const Sint16 * vy,
+	SDL3_GFXPRIMITIVES_SCOPE bool aapolygonColor(SDL_Renderer * renderer, const float * vx, const float * vy, int n, Uint32 color);
+	SDL3_GFXPRIMITIVES_SCOPE bool aapolygonRGBA(SDL_Renderer * renderer, const float * vx, const float * vy,
 		int n, Uint8 r, Uint8 g, Uint8 b, Uint8 a);
 
 	/* Filled Polygon */
 
-	SDL3_GFXPRIMITIVES_SCOPE bool filledPolygonColor(SDL_Renderer * renderer, const Sint16 * vx, const Sint16 * vy, int n, Uint32 color);
-	SDL3_GFXPRIMITIVES_SCOPE bool filledPolygonRGBA(SDL_Renderer * renderer, const Sint16 * vx,
-		const Sint16 * vy, int n, Uint8 r, Uint8 g, Uint8 b, Uint8 a);
+	SDL3_GFXPRIMITIVES_SCOPE bool filledPolygonColor(SDL_Renderer * renderer, const float * vx, const float * vy, int n, Uint32 color);
+	SDL3_GFXPRIMITIVES_SCOPE bool filledPolygonRGBA(SDL_Renderer * renderer, const float * vx,
+		const float * vy, int n, Uint8 r, Uint8 g, Uint8 b, Uint8 a);
 
 	/* Textured Polygon */
 
-	SDL3_GFXPRIMITIVES_SCOPE bool texturedPolygon(SDL_Renderer * renderer, const Sint16 * vx, const Sint16 * vy, int n, SDL_Surface * texture,int texture_dx,int texture_dy);
+	SDL3_GFXPRIMITIVES_SCOPE bool texturedPolygon(SDL_Renderer * renderer, const float * vx, const float * vy, int n, SDL_Surface * texture,int texture_dx,int texture_dy);
 
 	/* Bezier */
 
-	SDL3_GFXPRIMITIVES_SCOPE bool bezierColor(SDL_Renderer * renderer, const Sint16 * vx, const Sint16 * vy, int n, int s, Uint32 color);
-	SDL3_GFXPRIMITIVES_SCOPE bool bezierRGBA(SDL_Renderer * renderer, const Sint16 * vx, const Sint16 * vy,
+	SDL3_GFXPRIMITIVES_SCOPE bool bezierColor(SDL_Renderer * renderer, const float * vx, const float * vy, int n, int s, Uint32 color);
+	SDL3_GFXPRIMITIVES_SCOPE bool bezierRGBA(SDL_Renderer * renderer, const float * vx, const float * vy,
 		int n, int s, Uint8 r, Uint8 g, Uint8 b, Uint8 a);
 
 	/* Characters/Strings */
 
-	SDL3_GFXPRIMITIVES_SCOPE void gfxPrimitivesSetFont(const void *fontdata, Uint32 cw, Uint32 ch);
-	SDL3_GFXPRIMITIVES_SCOPE void gfxPrimitivesSetFontRotation(Uint32 rotation);
-	SDL3_GFXPRIMITIVES_SCOPE bool characterColor(SDL_Renderer * renderer, Sint16 x, Sint16 y, char c, Uint32 color);
-	SDL3_GFXPRIMITIVES_SCOPE bool characterRGBA(SDL_Renderer * renderer, Sint16 x, Sint16 y, char c, Uint8 r, Uint8 g, Uint8 b, Uint8 a);
-	SDL3_GFXPRIMITIVES_SCOPE bool stringColor(SDL_Renderer * renderer, Sint16 x, Sint16 y, const char *s, Uint32 color);
-	SDL3_GFXPRIMITIVES_SCOPE bool stringRGBA(SDL_Renderer * renderer, Sint16 x, Sint16 y, const char *s, Uint8 r, Uint8 g, Uint8 b, Uint8 a);
+	SDL3_GFXPRIMITIVES_SCOPE void gfxPrimitivesSetFont(const void *fontdata, unsigned int cw, unsigned int ch);
+	SDL3_GFXPRIMITIVES_SCOPE void gfxPrimitivesSetFontRotation(unsigned int rotation);
+	SDL3_GFXPRIMITIVES_SCOPE bool characterColor(SDL_Renderer * renderer, float x, float y, char c, Uint32 color);
+	SDL3_GFXPRIMITIVES_SCOPE bool characterRGBA(SDL_Renderer * renderer, float x, float y, char c, Uint8 r, Uint8 g, Uint8 b, Uint8 a);
+	SDL3_GFXPRIMITIVES_SCOPE bool stringColor(SDL_Renderer * renderer, float x, float y, const char *s, Uint32 color);
+	SDL3_GFXPRIMITIVES_SCOPE bool stringRGBA(SDL_Renderer * renderer, float x, float y, const char *s, Uint8 r, Uint8 g, Uint8 b, Uint8 a);
 
 	/* Ends C function definitions when using C++ */
 #ifdef __cplusplus

--- a/SDL3_gfxPrimitives.h
+++ b/SDL3_gfxPrimitives.h
@@ -119,9 +119,9 @@ extern "C" {
 
 	/* Thick Line */
 	SDL3_GFXPRIMITIVES_SCOPE bool thickLineColor(SDL_Renderer * renderer, float x1, float y1, float x2, float y2,
-		Uint8 width, Uint32 color);
+		float width, Uint32 color);
 	SDL3_GFXPRIMITIVES_SCOPE bool thickLineRGBA(SDL_Renderer * renderer, float x1, float y1, float x2, float y2,
-		Uint8 width, Uint8 r, Uint8 g, Uint8 b, Uint8 a);
+		float width, Uint8 r, Uint8 g, Uint8 b, Uint8 a);
 
 	/* Circle */
 

--- a/test/TestGfx.c
+++ b/test/TestGfx.c
@@ -34,22 +34,22 @@ static SDLTest_CommonState *state;
 #define NUM_RANDOM	4096
 
 /* Coordinates */
-static Sint16 rx[NUM_RANDOM], rx[NUM_RANDOM], ry[NUM_RANDOM], ry[NUM_RANDOM];
+static float rx[NUM_RANDOM], rx[NUM_RANDOM], ry[NUM_RANDOM], ry[NUM_RANDOM];
 
 /* Triangles */
-static Sint16 tx1[NUM_RANDOM][3], tx1[NUM_RANDOM][3], ty1[NUM_RANDOM][3], ty1[NUM_RANDOM][3];
+static float tx1[NUM_RANDOM][3], tx1[NUM_RANDOM][3], ty1[NUM_RANDOM][3], ty1[NUM_RANDOM][3];
 
 /* Squares (made of 2 triangles) */
-static Sint16 sx1[NUM_RANDOM][6], sx1[NUM_RANDOM][6], sy1[NUM_RANDOM][6], sy1[NUM_RANDOM][6];
+static float sx1[NUM_RANDOM][6], sx1[NUM_RANDOM][6], sy1[NUM_RANDOM][6], sy1[NUM_RANDOM][6];
 
 /* Line widths */
-static Uint8 lw[NUM_RANDOM];
+static float lw[NUM_RANDOM];
 
 /* Radii and offsets */
-static Sint16 rr1[NUM_RANDOM], rr2[NUM_RANDOM];
+static float rr1[NUM_RANDOM], rr2[NUM_RANDOM];
 
 /* Start and stop angles */
-static Sint16 a1[NUM_RANDOM], a2[NUM_RANDOM];
+static int a1[NUM_RANDOM], a2[NUM_RANDOM];
 
 /* RGB colors and alpha */
 static char rr[NUM_RANDOM], rg[NUM_RANDOM], rb[NUM_RANDOM], ra[NUM_RANDOM];
@@ -156,7 +156,7 @@ void ClearScreen(SDL_Renderer *renderer, const char *title)
 	int x,y;
 	float stepx, stepy, fx, fy, fxy;
 	char titletext[TLEN+1];
-	Sint16 textlength;
+	int textlength;
 
 	/* Clear the screen */
     SDL_SetRenderDrawColor(renderer, 0, 0, 0, 255);
@@ -170,7 +170,7 @@ void ClearScreen(SDL_Renderer *renderer, const char *title)
 		fy=0.0;
 		for (y=(HEIGHT-40)/2+60; y<HEIGHT; y++) {
 			fxy=1.0f-fx*fy;
-			pixelRGBA(renderer,x,y,(int)(128.0*fx*fx),(int)(128.0*fxy*fxy),(int)(128.0*fy*fy),255);
+			pixelRGBA(renderer,x,y,128.0f*fx*fx,128.0f*fxy*fxy,128.0f*fy*fy,255);
 			fy += stepy;
 		}
 		fx += stepx;
@@ -185,19 +185,19 @@ void ClearScreen(SDL_Renderer *renderer, const char *title)
 	SDL_strlcpy(titletext,"Current Primitive: ",TLEN);
 	SDL_strlcat(titletext,title,TLEN);
 	SDL_strlcat(titletext,"  -  Space to continue. ESC to Quit.",TLEN);
-	textlength = (Sint16)strlen(titletext);
+	textlength = (int)strlen(titletext);
 	stringRGBA (renderer, WIDTH/2-4*textlength,10-4,titletext,255,255,0,255);
 	SDL_strlcpy(titletext,"A=255 on Black",TLEN);
-	textlength = (Sint16)strlen(titletext);
+	textlength = (int)strlen(titletext);
 	stringRGBA (renderer, WIDTH/4-4*textlength,50-4,titletext,255,255,255,255);
 	SDL_strlcpy(titletext,"A=0-254 on Black",TLEN);
-	textlength = (Sint16)strlen(titletext);
+	textlength = (int)strlen(titletext);
 	stringRGBA (renderer, 3*WIDTH/4-4*textlength,50-4,titletext,255,255,255,255);
 	SDL_strlcpy(titletext,"A=255, Color Test",TLEN);
-	textlength = (Sint16)strlen(titletext);
+	textlength = (int)strlen(titletext);
 	stringRGBA (renderer, WIDTH/4-4*textlength,(HEIGHT-40)/2+50-4,titletext,255,255,255,255);
 	SDL_strlcpy(titletext,"A=0-254 on Color",TLEN);
-	textlength = (Sint16)strlen(titletext);
+	textlength = (int)strlen(titletext);
 	stringRGBA (renderer, 3*WIDTH/4-4*textlength,(HEIGHT-40)/2+50-4,titletext,255,255,255,255);
 }
 
@@ -206,7 +206,7 @@ void ClearCenter(SDL_Renderer *renderer, const char *title)
 {
 	SDL_FRect r;
 	int i, j;
-	Sint16 textlength;
+	int textlength;
 
 	r.x = WIDTH/2 - 60;
 	r.y = HEIGHT/2 - 30;
@@ -223,7 +223,7 @@ void ClearCenter(SDL_Renderer *renderer, const char *title)
 		  SDL_RenderPoint(renderer, WIDTH/2 + i, HEIGHT/2 + j);
 	  }
 	}
-	textlength = (Sint16)strlen(title);
+	textlength = (int)strlen(title);
 	stringRGBA (renderer, WIDTH/2 - 4*textlength,r.y + 2,title,255,255,255,255);
 }
 
@@ -234,7 +234,7 @@ void ExecuteTest(SDL_Renderer *renderer, PrimitivesTestCaseFp testCase, int test
 {
 	char titletext[TLEN+1];
     Uint64 then, now, numPrimitives;
-	Sint16 textlength;
+	int textlength;
 
 	ClearScreen(renderer, testName);
 	then = SDL_GetTicks();
@@ -243,7 +243,7 @@ void ExecuteTest(SDL_Renderer *renderer, PrimitivesTestCaseFp testCase, int test
     if (now > then) {
         double fps = ((double) numPrimitives * 1000) / (now - then);
         SDL_snprintf(titletext, TLEN, "Test %2i %20s: %10.1f /sec", testNum, testName, fps);
-		textlength = (Sint16)strlen(titletext);
+		textlength = (int)strlen(titletext);
 	    stringRGBA (renderer, WIDTH/2-4*textlength,30-4,titletext,255,255,255,255);
 		SDL_Log("%s", titletext);
     }
@@ -254,7 +254,7 @@ void ExecuteTest(SDL_Renderer *renderer, PrimitivesTestCaseFp testCase, int test
 int TestPixel(SDL_Renderer *renderer)
 {
 	int i;
-	char r,g,b;
+	Uint8 r,g,b;
 	int step = 1;
 
 	/* Draw A=255 */
@@ -301,7 +301,7 @@ int TestPixel(SDL_Renderer *renderer)
 int TestHline(SDL_Renderer *renderer)
 {
 	int i;
-	char r,g,b;
+	Uint8 r,g,b;
 	int step = 2;
 
 	/* Draw A=255 */
@@ -348,7 +348,7 @@ int TestHline(SDL_Renderer *renderer)
 int TestVline(SDL_Renderer *renderer)
 {
 	int i;
-	char r,g,b;
+	Uint8 r,g,b;
 	int step = 2;
 
 	/* Draw A=255 */
@@ -395,7 +395,7 @@ int TestVline(SDL_Renderer *renderer)
 int TestRectangle(SDL_Renderer *renderer)
 {
 	int i;
-	char r,g,b;
+	Uint8 r,g,b;
 	int step = 2;
 
 	/* Draw A=255 */
@@ -442,7 +442,7 @@ int TestRectangle(SDL_Renderer *renderer)
 int TestRoundedRectangle(SDL_Renderer *renderer)
 {
 	int i;
-	char r,g,b;
+	Uint8 r,g,b;
 	int step = 2;
 
 	/* Draw A=255 */
@@ -489,7 +489,7 @@ int TestRoundedRectangle(SDL_Renderer *renderer)
 int TestBox(SDL_Renderer *renderer)
 {
 	int i;
-	char r,g,b;
+	Uint8 r,g,b;
 	int step = 2;
 
 	/* Draw A=255 */
@@ -536,7 +536,7 @@ int TestBox(SDL_Renderer *renderer)
 int TestRoundedBox(SDL_Renderer *renderer)
 {
 	int i;
-	char r,g,b;
+	Uint8 r,g,b;
 	int step = 2;
 
 	/* Draw A=255 */
@@ -583,7 +583,7 @@ int TestRoundedBox(SDL_Renderer *renderer)
 int TestLine(SDL_Renderer *renderer)
 {
 	int i;
-	char r,g,b;
+	Uint8 r,g,b;
 	int step = 2;
 
 	/* Draw A=255 */
@@ -680,7 +680,7 @@ int TestAALine(SDL_Renderer *renderer)
 int TestCircle(SDL_Renderer *renderer)
 {
 	int i;
-	char r,g,b;
+	Uint8 r,g,b;
 	int step = 2;
 
 	/* Draw A=255 */
@@ -727,7 +727,7 @@ int TestCircle(SDL_Renderer *renderer)
 int TestAACircle(SDL_Renderer *renderer)
 {
 	int i;
-	char r,g,b;
+	Uint8 r,g,b;
 	int step = 4;
 
 	/* Draw A=255 */
@@ -774,7 +774,7 @@ int TestAACircle(SDL_Renderer *renderer)
 int TestFilledCircle(SDL_Renderer *renderer)
 {
 	int i;
-	char r,g,b;
+	Uint8 r,g,b;
 	int step = 2;
 
 	/* Draw A=255 */
@@ -821,7 +821,7 @@ int TestFilledCircle(SDL_Renderer *renderer)
 int TestEllipse(SDL_Renderer *renderer)
 {
 	int i;
-	char r,g,b;
+	Uint8 r,g,b;
 	int step = 2;
 
 	/* Draw A=255 */
@@ -868,7 +868,7 @@ int TestEllipse(SDL_Renderer *renderer)
 int TestAAEllipse(SDL_Renderer *renderer)
 {
 	int i;
-	char r,g,b;
+	Uint8 r,g,b;
 	int step = 4;
 
 	/* Draw A=255 */
@@ -915,7 +915,7 @@ int TestAAEllipse(SDL_Renderer *renderer)
 int TestFilledEllipse(SDL_Renderer *renderer)
 {
 	int i;
-	char r,g,b;
+	Uint8 r,g,b;
 	int step = 2;
 
 	/* Draw A=255 */
@@ -962,7 +962,7 @@ int TestFilledEllipse(SDL_Renderer *renderer)
 int TestBezier(SDL_Renderer *renderer)
 {
 	int i;
-	char r,g,b;
+	Uint8 r,g,b;
 	int step = 5;
 
 	/* Draw A=255 */
@@ -1016,7 +1016,7 @@ int TestBezier(SDL_Renderer *renderer)
 int TestPolygon(SDL_Renderer *renderer)
 {
 	int i;
-	char r,g,b;
+	Uint8 r,g,b;
 	int step = 3;
 
 	/* Draw A=255 */
@@ -1070,7 +1070,7 @@ int TestPolygon(SDL_Renderer *renderer)
 int TestAAPolygon(SDL_Renderer *renderer)
 {
 	int i;
-	char r,g,b;
+	Uint8 r,g,b;
 	int step = 4;
 
 	/* Draw A=255 */
@@ -1124,7 +1124,7 @@ int TestAAPolygon(SDL_Renderer *renderer)
 int TestFilledPolygon(SDL_Renderer *renderer)
 {
 	int i;
-	char r,g,b;
+	Uint8 r,g,b;
 	int step = 4;
 
 	/* Draw A=255 */
@@ -1178,7 +1178,7 @@ int TestFilledPolygon(SDL_Renderer *renderer)
 int TestTrigon(SDL_Renderer *renderer)
 {
 	int i;
-	char r,g,b;
+	Uint8 r,g,b;
 	int step = 1;
 
 	/* Draw A=255 */
@@ -1228,7 +1228,7 @@ int TestTrigon(SDL_Renderer *renderer)
 int TestArc(SDL_Renderer *renderer)
 {
 	int i;
-	char r,g,b;
+	Uint8 r,g,b;
 	int step = 1;
 
 	/* Draw A=255 */
@@ -1275,7 +1275,7 @@ int TestArc(SDL_Renderer *renderer)
 int TestPie(SDL_Renderer *renderer)
 {
 	int i;
-	char r,g,b;
+	Uint8 r,g,b;
 	int step = 1;
 
 	/* Draw A=255 */
@@ -1322,7 +1322,7 @@ int TestPie(SDL_Renderer *renderer)
 int TestFilledPie(SDL_Renderer *renderer)
 {
 	int i;
-	char r,g,b;
+	Uint8 r,g,b;
 	int step = 1;
 
 	/* Draw A=255 */
@@ -1369,7 +1369,7 @@ int TestFilledPie(SDL_Renderer *renderer)
 int TestThickLine(SDL_Renderer *renderer)
 {
 	int i;
-	char r,g,b;
+	Uint8 r,g,b;
 	int step = 6;
 	
 	/* Draw A=255 */
@@ -1470,15 +1470,15 @@ int TestTexturedPolygon(SDL_Renderer *renderer)
 {
 	/* Define masking bytes */
 #if SDL_BYTEORDER == SDL_BIG_ENDIAN
-	Uint32 rmask = 0xff000000; 
-	Uint32 gmask = 0x00ff0000;
-	Uint32 bmask = 0x0000ff00; 
-	Uint32 amask = 0x000000ff;
+	unsigned int rmask = 0xff000000;
+	unsigned int gmask = 0x00ff0000;
+	unsigned int bmask = 0x0000ff00;
+	unsigned int amask = 0x000000ff;
 #else
-	Uint32 amask = 0xff000000; 
-	Uint32 bmask = 0x00ff0000;
-	Uint32 gmask = 0x0000ff00; 
-	Uint32 rmask = 0x000000ff;
+	unsigned int amask = 0xff000000;
+	unsigned int bmask = 0x00ff0000;
+	unsigned int gmask = 0x0000ff00;
+	unsigned int rmask = 0x000000ff;
 #endif
 	int i;
 	int step = 24;
@@ -1605,7 +1605,7 @@ int TestBigCircle(SDL_Renderer *renderer)
 				circleRGBA(renderer,
 					WIDTH / 2,
 					HEIGHT / (2 - k + 1),
-					(Sint16)(256 * k - 1 + 2 * j),
+					256 * k - 1 + 2 * j,
 					r,
 					g,
 					b,
@@ -1675,8 +1675,8 @@ int TestBigEllipse(SDL_Renderer *renderer)
 				ellipseRGBA(renderer,
 					WIDTH / 2,
 					HEIGHT / 2,
-					(Sint16)(256 * k - 1 + 2 * j),
-					(Sint16)(256 * k - 1 - 2 * j),
+					256 * k - 1 + 2 * j,
+					256 * k - 1 - 2 * j,
 					r,
 					g,
 					b,
@@ -1685,8 +1685,8 @@ int TestBigEllipse(SDL_Renderer *renderer)
 				ellipseRGBA(renderer,
 					WIDTH / 2,
 					HEIGHT / 2,
-					(Sint16)(256 * k - 1 - 2 * j),
-					(Sint16)(256 * k - 1 + 2 * j),
+					256 * k - 1 - 2 * j,
+					256 * k - 1 + 2 * j,
 					r,
 					g,
 					b,


### PR DESCRIPTION
## About this PR

This PR changes the method signatures in Gfx_primtives to:

* Support float types instead fo `SInt16`
* ~Eliminate the use of SDL types to be more C standard in the signatures. Only use SDL type when its explicitly important to note the type size (i.e colors must be `UInt32` and `Uint8` per channel, so those remain that way)~
  * This was changed, instead use SDL types when it makes sense in the signature. Mostly for portability. A Separate PR will be needed to see when using certain SDL method that require normal standard types int should be used to avoid narrowing conversions, or use explicit casting possibly.

This PR tries to avoid changing too much the insides of the methods to keep their inner working as expected from the original implementation.

This fixes #10 and fixes #14

## Reasoning

This is part of the effort to make this API follow the SDL3 API standard, and update the methods to support the new float render elements.

The two main change are to change all to floats, and removing all parameters that do not explicitly require and SDL type to use a standard type, like the main SDL3 API signatures do.

## Results

Seems to work OK?  I tested the `TestGfx` program and the precision calls seem to work O at the very least.

## Remarks

So yeah, this is a more-less flimsy PR. This would match the usage fo floats in all signature, but you can definitely see a lot of narrowing conversions from float to int within the inner APIs. Not sure if that is too much of a bad thing.

It does work at least, and couldn't see any particular problems within the test itself.

Let me know if this Pr even makes sense.
