### PR TITLE
FIX: Infinite loop when drawing circles/ellipses with radii between 0 and 1

### DIFF
--- a/SDL3_gfxPrimitives.c
+++ b/SDL3_gfxPrimitives.c
@@ -1542,9 +1542,20 @@ bool _ellipseRGBA(SDL_Renderer * renderer, float x, float y, float rx, float ry,
 			return (hline(renderer, x - rx, x + rx, y));
 		}
 	}
-	
+
 	/*
- 	 * Adjust overscan 
+	* Special case for radii > 0 and < 1
+	*/
+	if (rx > 0 && rx < 1) {
+		rx = 1.0f;
+	}
+
+	if (ry > 0 && ry < 1) {
+		ry = 1.0f;
+	}
+
+	/*
+ 	 * Adjust overscan
 	 */
 	rxi = rx;
 	ryi = ry;

--- a/test/TestGfx.c
+++ b/test/TestGfx.c
@@ -102,8 +102,15 @@ void InitRandomPoints(int seed)
 		lw[i]=2 + (rand() % 7);
 
 		/* Random Radii */
-		rr1[i]=rand() % 32;
-		rr2[i]=rand() % 32;
+		if (i == 0) {
+			/* Special case for radii bigger than 0 and less than 1 */
+			rr1[i]=0.5f;
+			rr2[i]=0.25f;
+		} else {
+			rr1[i]=rand() % 32;
+			rr2[i]=rand() % 32;
+		}
+
 
 		/* Random Angles */
 		a1[i]=rand() % 360;


### PR DESCRIPTION
## Summary

This PR adds a special case check on ellipses (and thus circles) when using radii between 0 and 1.
This also adds one entry in the radii `TestGfx.c` list that should test this issue in the future.

If approved, this fixes #19.

## Remarks

This is a quick fix that should be addressed fully and made moot when using a modern way to paint primitives with floats rather than still using the old integer algorithms.